### PR TITLE
Add 2.8<= version match rule to Xtext dependencies

### DIFF
--- a/features/hu.elte.txtuml.feature/feature.xml
+++ b/features/hu.elte.txtuml.feature/feature.xml
@@ -136,24 +136,24 @@ This Agreement is governed by the laws of the State of New York and the intellec
       <import plugin="org.eclipse.jdt.core" version="3.10.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jface"/>
       <import plugin="org.eclipse.ui"/>
-      <import plugin="org.eclipse.xtext"/>
+      <import plugin="org.eclipse.xtext" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.equinox.common" version="3.5.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.xtext.util"/>
+      <import plugin="org.eclipse.xtext.util" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.common"/>
-      <import plugin="org.eclipse.xtext.xbase.lib"/>
+      <import plugin="org.eclipse.xtext.xbase.lib" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.antlr.runtime"/>
-      <import plugin="org.eclipse.xtext.common.types"/>
-      <import plugin="org.eclipse.xtext.xbase"/>
+      <import plugin="org.eclipse.xtext.common.types" version="2.8" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.xtext.xbase" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j"/>
-      <import plugin="org.eclipse.xtext.ui"/>
+      <import plugin="org.eclipse.xtext.ui" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.editors" version="3.5.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.ui.ide" version="3.5.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.xtext.ui.shared"/>
-      <import plugin="org.eclipse.xtext.xbase.ui"/>
-      <import plugin="org.eclipse.xtext.builder"/>
-      <import plugin="org.eclipse.xtext.common.types.ui"/>
+      <import plugin="org.eclipse.xtext.ui.shared" version="2.8" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.xtext.xbase.ui" version="2.8" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.xtext.builder" version="2.8" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.xtext.common.types.ui" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.jdt.debug.ui"/>
-      <import plugin="org.eclipse.xtext.ui.codetemplates.ui"/>
+      <import plugin="org.eclipse.xtext.ui.codetemplates.ui" version="2.8" match="greaterOrEqual"/>
       <import plugin="org.eclipse.compare"/>
       <import plugin="com.google.guava"/>
       <import plugin="org.eclipse.xtend.lib"/>


### PR DESCRIPTION
This resolves #10.

However, if we will release v0.2.0 to Luna, manually adding a newer Xtext update site will be necessary for Eclipse to be able to automatically install the required Xtext bundles, as the included update site in Luna provides Xtext only up to version 2.7.3.