### PR TITLE
Fix resolution of partially qualified names

### DIFF
--- a/examples/hu.elte.txtuml.examples.performance-test/src/ErrorReportingModel.xtxtuml
+++ b/examples/hu.elte.txtuml.examples.performance-test/src/ErrorReportingModel.xtxtuml
@@ -1,6 +1,0 @@
-
-model ErrorReportingModel {
-	class A {
-		
-	}
-}

--- a/examples/hu.elte.txtuml.examples.performance-test/src/PerformanceTestModel.xtxtuml
+++ b/examples/hu.elte.txtuml.examples.performance-test/src/PerformanceTestModel.xtxtuml
@@ -3,7 +3,7 @@ model PerformanceTestModel {
 	class Test {
 				
 		public void test() {
-			PerformanceTestModel.A a = create(A, 10000);
+			A a = create(A, 10000);
 			start(a);
 		}
 		
@@ -23,7 +23,7 @@ model PerformanceTestModel {
 		state A1 {
 			entry {
 				if (remainingCycles-- <= 0) {
-					for (PerformanceTestModel.B b in A.this->PerformanceTestModel::AB::b) {
+					for (B b in A.this->AB::b) {
 						unlink(AB.a, A.this, AB.b, b);
 					}
 					delete A.this;
@@ -36,7 +36,7 @@ model PerformanceTestModel {
 		
 		private void createChild() {
 			// B b = new B();
-			PerformanceTestModel.B b = new PerformanceTestModel.B();
+			B b = new B();
 			link(AB.a, this, AB.b, b);
 			start(b);
 		}
@@ -63,12 +63,12 @@ model PerformanceTestModel {
 			trigger Forward;
 			effect {
 				// log("A1->A2");
-				PerformanceTestModel.Forward sig = getSignal(PerformanceTestModel.Forward);
+				Forward sig = getSignal(Forward);
 				if (sig.nf % 4 == 0) {
 					createChild();
 				}
-				if (!A.this->PerformanceTestModel::AB::b.isEmpty()) {
-					send new Forward(0) to A.this->PerformanceTestModel::AB::b.selectAny();
+				if (!A.this->AB::b.isEmpty()) {
+					send new Forward(0) to A.this->AB::b.selectAny();
 				}
 				numForward++;
 				send new Forward(numForward) to A.this;
@@ -81,12 +81,12 @@ model PerformanceTestModel {
 			trigger Forward;
 			effect {
 				// log("A2->A3");
-				PerformanceTestModel.Forward sig = getSignal(PerformanceTestModel.Forward);
+				Forward sig = getSignal(Forward);
 				if (sig.nf % 4 == 0) {
 					createChild();
 				}
-				if (!A.this->PerformanceTestModel::AB::b.isEmpty()) {
-					send new Forward(0) to A.this->PerformanceTestModel::AB::b.selectAny();
+				if (!A.this->AB::b.isEmpty()) {
+					send new Forward(0) to A.this->AB::b.selectAny();
 				}
 				numForward++;
 				send new Forward(numForward) to A.this;
@@ -99,12 +99,12 @@ model PerformanceTestModel {
 			trigger Forward;
 			effect {
 				// log("A3->A4");
-				PerformanceTestModel.Forward sig = getSignal(PerformanceTestModel.Forward);
+				Forward sig = getSignal(Forward);
 				if (sig.nf % 4 == 0) {
 					createChild();
 				}
-				if (!A.this->PerformanceTestModel::AB::b.isEmpty()) {
-					send new Forward(0) to A.this->PerformanceTestModel::AB::b.selectAny();
+				if (!A.this->AB::b.isEmpty()) {
+					send new Forward(0) to A.this->AB::b.selectAny();
 				}
 				numForward++;
 				send new Forward(numForward) to A.this;
@@ -117,12 +117,12 @@ model PerformanceTestModel {
 			trigger Forward;
 			effect {
 				// log("A4->A1");
-				PerformanceTestModel.Forward sig = getSignal(PerformanceTestModel.Forward);
+				Forward sig = getSignal(Forward);
 				if (sig.nf % 4 == 0) {
 					createChild();
 				}
-				if (!A.this->PerformanceTestModel::AB::b.isEmpty()) {
-					send new Forward(0) to A.this->PerformanceTestModel::AB::b.selectAny();
+				if (!A.this->AB::b.isEmpty()) {
+					send new Forward(0) to A.this->AB::b.selectAny();
 				}
 				numForward++;
 				send new Forward(numForward) to A.this;
@@ -173,10 +173,10 @@ model PerformanceTestModel {
 		state B4;
 		state finalstate {
 			entry {
-				if (B.this->PerformanceTestModel::AB::a.isEmpty()) {
+				if (B.this->AB::a.isEmpty()) {
 				} else {
-					PerformanceTestModel.A a = B.this->PerformanceTestModel::AB::a.selectAny();
-					unlink(PerformanceTestModel.AB.a, a, AB.b, PerformanceTestModel.B.this);
+					A a = B.this->AB::a.selectAny();
+					unlink(AB.a, a, AB.b, B.this);
 					a.childTerminated();
 				}
 				delete B.this;

--- a/examples/hu.elte.txtuml.examples.performance-test/src/PerformanceTester.java
+++ b/examples/hu.elte.txtuml.examples.performance-test/src/PerformanceTester.java
@@ -19,11 +19,11 @@ public class PerformanceTester {
 		
 		ModelExecutor.Settings.setDynamicChecks(false);
 
-		PerformanceTestModel_.Test m = Action
-				.create(PerformanceTestModel_.Test.class);
+//		PerformanceTestModel_.Test m = Action
+//				.create(PerformanceTestModel_.Test.class);
 
-//		PerformanceTestModel.Test m = Action
-//				.create(PerformanceTestModel.Test.class);
+		PerformanceTestModel.Test m = Action
+				.create(PerformanceTestModel.Test.class);
 		
 		m.test();
 		

--- a/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLImportNormalizer.xtend
+++ b/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLImportNormalizer.xtend
@@ -1,0 +1,52 @@
+package hu.elte.txtuml.xtxtuml.scoping
+
+import org.eclipse.xtext.xbase.scoping.NestedTypeAwareImportNormalizerWithDotSeparator
+import org.eclipse.xtext.naming.QualifiedName
+import java.util.ArrayList
+
+class XtxtUMLImportNormalizer extends NestedTypeAwareImportNormalizerWithDotSeparator {
+
+	new(QualifiedName importedNamespace, boolean wildcard, boolean ignoreCase) {
+		super(importedNamespace, wildcard, ignoreCase);
+	}
+	
+	override protected resolveWildcard(QualifiedName relativeName) {
+		getImportedNamespacePrefix().append(relativeName);	
+	}
+	
+	override deresolve(QualifiedName fullyQualifiedName) {
+		var oldSegments = fullyQualifiedName.segments;
+		var newSegments = new ArrayList<String>();
+		
+		for (segment : getImportedNamespacePrefix().segments) {
+			if (segment != oldSegments.head) {
+				val oldSegmentsSplittedHead = oldSegments.head.split("\\$");
+				
+				val tempOldSegments = new ArrayList<String>();
+				tempOldSegments.add(oldSegmentsSplittedHead.head);
+				tempOldSegments.add(oldSegmentsSplittedHead.drop(1).join("$"));
+				tempOldSegments.addAll(oldSegments.drop(1));
+				
+				oldSegments = tempOldSegments;
+			}
+			
+			while (segment != oldSegments.head) {
+				val oldSegmentsSplittedSecond = oldSegments.get(1).split("\\$");
+				
+				val tempOldSegments = new ArrayList<String>();
+				tempOldSegments.add(oldSegments.head + "$" + oldSegmentsSplittedSecond.head);
+				tempOldSegments.add(oldSegmentsSplittedSecond.drop(1).join("$"));
+				tempOldSegments.addAll(oldSegments.drop(2));
+				
+				oldSegments = tempOldSegments;
+			}
+			
+			newSegments.add(segment);
+			oldSegments = oldSegments.drop(1).toList();
+		}
+
+		newSegments.addAll(oldSegments);
+		super.deresolve(QualifiedName::create(newSegments));
+	}
+	
+}

--- a/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLMultimapBasedSelectable.xtend
+++ b/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLMultimapBasedSelectable.xtend
@@ -1,0 +1,39 @@
+package hu.elte.txtuml.xtxtuml.scoping
+
+import org.eclipse.xtext.scoping.impl.MultimapBasedSelectable;
+import org.eclipse.xtext.resource.IEObjectDescription
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.emf.ecore.EClass
+import java.util.ArrayList
+
+class XtxtUMLMultimapBasedSelectable extends MultimapBasedSelectable {
+	
+	new(Iterable<IEObjectDescription> allDescriptions) {
+		super(allDescriptions);
+	}
+	
+	override getExportedObjects(EClass type, QualifiedName name, boolean ignoreCase) {
+		var result = super.getExportedObjects(type, name, ignoreCase);
+		
+		if (type.name == "JvmType") {
+			var currentName = name;
+			while (currentName.segmentCount > 1) {
+				val currentSegments = currentName.segments;
+				
+				val newSegments = new ArrayList<String>();
+				newSegments.addAll(currentSegments.take(currentName.segmentCount - 2));
+				newSegments.add(currentSegments.drop(currentName.segmentCount - 2).join("$"));
+				currentName = QualifiedName::create(newSegments);
+				
+				val newResult = new ArrayList<IEObjectDescription>();
+				newResult.addAll(result);
+				newResult.addAll(super.getExportedObjects(type, currentName, ignoreCase));
+				
+				result = newResult;
+			}
+		}
+		
+		return result;
+	}
+	
+}

--- a/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLXImportSectionNamespaceScopeProvider.xtend
+++ b/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/scoping/XtxtUMLXImportSectionNamespaceScopeProvider.xtend
@@ -1,14 +1,24 @@
 package hu.elte.txtuml.xtxtuml.scoping
 
-import org.eclipse.xtext.xbase.scoping.XImportSectionNamespaceScopeProvider;
-import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.naming.QualifiedName
+import org.eclipse.xtext.xbase.scoping.XImportSectionNamespaceScopeProvider
 
 class XtxtUMLXImportSectionNamespaceScopeProvider extends XImportSectionNamespaceScopeProvider {
-	
-	protected override getImplicitImports(boolean ignoreCase) {
+
+	override protected getImplicitImports(boolean ignoreCase) {
 		(super.getImplicitImports(ignoreCase) + #[
 			doCreateImportNormalizer(QualifiedName::create("hu", "elte", "txtuml", "xtxtuml", "lib"), true, false)
 		]).toList
 	}
-	
+
+	override protected internalGetAllDescriptions(Resource resource) {
+		return new XtxtUMLMultimapBasedSelectable(super.internalGetAllDescriptions(resource).exportedObjects);
+	}
+
+	override protected doCreateImportNormalizer(QualifiedName importedNamespace, boolean wildcard,
+		boolean ignoreCase) {
+		return new XtxtUMLImportNormalizer(importedNamespace, wildcard, ignoreCase);
+	}
+
 }


### PR DESCRIPTION
This is intended to fix #25.

By default in Xtext, references to local elements using partially qualified names are made possible with *local imports*. That is, when the hierarchical scope for a given context is being built, an implicit wildcard import statement is added for each nesting level. Given that the scope building process is correct (which fortunately is), the key aspect becomes the import resolution, which was the reason behind the mentioned problems indeed.

More precisely, the issue was caused mainly by the improper handling of Xtext's internal representation of qualified names during import resolution. In case of qualified names of nested types, Xtext uses the `.` character for language entities, and the `$` sign for their inferred `JvmType` counterparts to separate name segments. Consider the following example:

```
package p;

model M {
    class A;
}
```

Here `p.M.A` identifies the *language entity* corresponding to `A`, whereas `p.M$A` is the internal identifier of the *inferred Java class* (actually, only of its internal EMF representation).

Even though this solution can help distinguish between language and Java entities inside the framework, in our case it was the reason why partially qualified names couldn't be properly resolved. Technically speaking, some of these names *could be* resolved when certain conditions were met, but always to Java entities, resulting in type mismatches if language entites were expected instead.

To overcome the issue, I've redefined some aspects of the default import resolution process and adjusted the closely connected scoping components accordingly.

I hope I haven't broken anything.