### PR TITLE
Implement custom multiplicities in XtxtUML

### DIFF
--- a/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/jvmmodel/XtxtUMLJvmModelInferrer.xtend
+++ b/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/jvmmodel/XtxtUMLJvmModelInferrer.xtend
@@ -19,24 +19,24 @@ import org.eclipse.xtext.xbase.jvmmodel.AbstractModelInferrer;
 import org.eclipse.xtext.xbase.jvmmodel.IJvmDeclaredTypeAcceptor;
 
 // XtxtUML
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUModel
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUClass
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUState
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignal
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUAttribute
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUExecution
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUOperation
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransition
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUVisibility
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociation
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUConstructor
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociationEnd
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignalAttribute
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionGuard
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionEffect
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionTrigger
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUEntryOrExitActivity
-import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionVertex
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUModel;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUClass;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUState;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignal;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAttribute;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUExecution;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUOperation;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransition;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUVisibility;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociation;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUConstructor;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociationEnd;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignalAttribute;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionGuard;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionEffect;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionTrigger;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUEntryOrExitActivity;
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransitionVertex;
 
 class XtxtUMLJvmModelInferrer extends AbstractModelInferrer {
 
@@ -260,7 +260,18 @@ class XtxtUMLJvmModelInferrer extends AbstractModelInferrer {
 	def dispatch private toJvmMember(TUAssociationEnd end) {
 		end.toClass(end.fullyQualifiedName) [
 			visibility = JvmVisibility.PUBLIC;
-			superTypes += end.calculateApiSuperType;
+			
+			val calcApiSuperTypeResult = end.calculateApiSuperType
+			superTypes += calcApiSuperTypeResult.key;
+			
+			if (calcApiSuperTypeResult.value != null) {
+				annotations += calcApiSuperTypeResult.value.key
+					.toAnnotationRef(hu.elte.txtuml.api.model.Min);
+				if (!end.multiplicity.isUpperInf) {
+					annotations += calcApiSuperTypeResult.value.value
+						.toAnnotationRef(hu.elte.txtuml.api.model.Max);
+				}
+			}
 		]
 	}
 	
@@ -298,17 +309,28 @@ class XtxtUMLJvmModelInferrer extends AbstractModelInferrer {
 			]
 		]
 	}
+	
+	def private toAnnotationRef(int i, java.lang.Class<?> annotationType) {
+		annotationRef(annotationType) => [
+			explicitValues += TypesFactory::eINSTANCE.createJvmIntAnnotationValue => [
+				values += i;
+			]
+		]
+	}
 
 	def private calculateApiSuperType(TUAssociationEnd it) {
 		val optionalHidden = if (notNavigable) "Hidden" else "";
+		var Pair<Integer, Integer> explicitMultiplicities = null;
 		val apiBoundTypeName
 		 = 	if (multiplicity.any) // *
 		 		"Many"
 		 	else if (!multiplicity.upperSet) { // <lower> (exact)
 		 		if (multiplicity.lower == 1)
 		 			"One"
-		 		else
-		 			"Many"
+		 		else {
+		 			explicitMultiplicities = multiplicity.lower -> multiplicity.lower;
+		 			"Multiple"
+		 		}		
 		 	} else { // <lower> .. <upper>
 		 		if (multiplicity.lower == 0 && multiplicity.upper == 1)
 					"MaybeOne"
@@ -318,13 +340,14 @@ class XtxtUMLJvmModelInferrer extends AbstractModelInferrer {
 					"Many"
 				else if (multiplicity.lower == 1 && multiplicity.upperInf)
 					"Some"
-				else
-					"Many"
+				else {
+					explicitMultiplicities = multiplicity.lower -> multiplicity.upper;
+					"Multiple"
+				}
 		 	}
 		
-		return ("hu.elte.txtuml.api.model.Association$" + optionalHidden + apiBoundTypeName)
-			.typeRef((endClass.getPrimaryJvmElement as JvmDeclaredType).typeRef);
+		return new Pair(("hu.elte.txtuml.api.model.Association$" + optionalHidden + apiBoundTypeName)
+			.typeRef((endClass.getPrimaryJvmElement as JvmDeclaredType).typeRef), explicitMultiplicities);
 	}
 
 }
-


### PR DESCRIPTION
Custom association(end) multiplicities have already been made available in JtxtUML, provided by the generic `Multiple` class and annotations `Min` and `Max`. For additional details, see the [language guide](http://txtuml.inf.elte.hu/wiki/doku.php?id=v020:language#associations).

I have now implemented these custom multiplicities for XtxtUML as well. The syntax is as follows:
```
<multiplicity> ::= <int> ('..' (<int> | '*'))? | '*'
```

Some concrete examples:
- `*`
- `1`
- `1..4`
- `2..*`

As always, the multiplicity should be specified *after* the access modifier and *before* the class identifier in an association end. For example:
```
association L {
    public 1..4 A a;
    public 2..* B b;
}
```