### PR TITLE
Instead of interruption, an explicit check is performed in every iteration of ModelExecutorThread's loop

### DIFF
--- a/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/ModelExecutor.java
+++ b/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/ModelExecutor.java
@@ -435,7 +435,7 @@ public final class ModelExecutor implements ModelElement {
 	public static void shutdownNow() {
 		Report.event.forEach(x -> x.executionTerminated());
 
-		thread.interrupt();
+		thread.inactivate();
 
 		terminationManager.notifyAllOfTermination();
 	}


### PR DESCRIPTION
To fix #112.