### PR TITLE
Action.create does not throw IllegalArgumentException.

### DIFF
--- a/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/Action.java
+++ b/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/Action.java
@@ -3,6 +3,7 @@ package hu.elte.txtuml.api.model;
 import hu.elte.txtuml.api.model.ModelExecutor.Report;
 import hu.elte.txtuml.api.model.backend.MultiplicityException;
 import hu.elte.txtuml.utils.InstanceCreator;
+import hu.elte.txtuml.utils.RuntimeInvocationTargetException;
 
 import java.lang.reflect.Modifier;
 
@@ -11,8 +12,8 @@ import java.lang.reflect.Modifier;
  * statements of the action language.
  * 
  * <p>
- * <b>Represents:</b> no model element directly, its static methods are part of the
- * action language
+ * <b>Represents:</b> no model element directly, its static methods are part of
+ * the action language
  * <p>
  * <b>Usage:</b>
  * <p>
@@ -28,7 +29,8 @@ import java.lang.reflect.Modifier;
  * </ul>
  * 
  * <p>
- * See the documentation of {@link Model} for an overview on modeling in JtxtUML.
+ * See the documentation of {@link Model} for an overview on modeling in
+ * JtxtUML.
  *
  * @author Gabor Ferenc Kovacs
  *
@@ -73,13 +75,13 @@ public class Action implements ModelElement {
 				params[i + 1] = parameters[i];
 			}
 		}
-		T obj = InstanceCreator
-				.create(classType, params);
-		if (obj == null) {
+		try {
+			return InstanceCreator.create(classType, params);
+		} catch (IllegalArgumentException | RuntimeInvocationTargetException e) {
 			Report.error.forEach(x -> x.modelObjectCreationFailed(classType,
 					parameters));
+			return null;
 		}
-		return obj;
 	}
 
 	/**

--- a/plugins/hu.elte.txtuml.utils/src/hu/elte/txtuml/utils/InstanceCreator.java
+++ b/plugins/hu.elte.txtuml.utils/src/hu/elte/txtuml/utils/InstanceCreator.java
@@ -25,7 +25,9 @@ public final class InstanceCreator {
 	 *             if the called constructor throws an exception
 	 */
 	public static <T> T create(Class<T> toInstantiate,
-			Object... constructorParams) {
+			Object... constructorParams) throws IllegalArgumentException,
+			RuntimeInvocationTargetException {
+
 		if (toInstantiate.isPrimitive()) {
 			if (constructorParams.length == 0) {
 				return getDefaultPrimitiveValue(toInstantiate);
@@ -55,7 +57,7 @@ public final class InstanceCreator {
 	 */
 	@SuppressWarnings("unchecked")
 	private static <T> T tryCreateWithConstructor(Constructor<?> ctor,
-			Object... givenParams) {
+			Object... givenParams) throws RuntimeInvocationTargetException {
 		Parameter[] params = ctor.getParameters();
 		Object[] actualParams = new Object[params.length];
 


### PR DESCRIPTION
Quick fix for #133.

Note:
Returning null will cause a NullPointerException in almost all cases, but it follows the original approach (to report the error and return null). In the long run, the error handling of the whole runtime will need a refactoring (see #131 ).