### PR TITLE
Ensured at Java compile time that an association end does not implement multiple interfaces that mark multiplicity or navigability

### DIFF
--- a/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/assocends/Multiplicity.java
+++ b/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/assocends/Multiplicity.java
@@ -12,7 +12,7 @@ package hu.elte.txtuml.api.model.assocends;
  * @author Gabor Ferenc Kovacs
  *
  */
-public interface Multiplicity {
+public interface Multiplicity<T extends Multiplicity<T>> {
 
 	/**
 	 * Implementing classes represent association ends with a multiplicity of
@@ -24,7 +24,7 @@ public interface Multiplicity {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface One extends Multiplicity {
+	public interface One extends Multiplicity<One> {
 	}
 
 	/**
@@ -37,7 +37,7 @@ public interface Multiplicity {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface ZeroToOne extends Multiplicity {
+	public interface ZeroToOne extends Multiplicity<ZeroToOne> {
 	}
 
 	/**
@@ -50,7 +50,7 @@ public interface Multiplicity {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface ZeroToUnlimited extends Multiplicity {
+	public interface ZeroToUnlimited extends Multiplicity<ZeroToUnlimited> {
 	}
 
 	/**
@@ -63,7 +63,7 @@ public interface Multiplicity {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface OneToUnlimited extends Multiplicity {
+	public interface OneToUnlimited extends Multiplicity<OneToUnlimited> {
 	}
 
 	/**
@@ -75,7 +75,7 @@ public interface Multiplicity {
 	 * 
 	 * @author Gabor Ferenc Kovacs
 	 */
-	public interface MinToMax extends Multiplicity {
+	public interface MinToMax extends Multiplicity<MinToMax> {
 	}
 
 }

--- a/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/assocends/Navigability.java
+++ b/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/assocends/Navigability.java
@@ -10,7 +10,7 @@ package hu.elte.txtuml.api.model.assocends;
  * @author Gabor Ferenc Kovacs
  *
  */
-public interface Navigability {
+public interface Navigability<T extends Navigability<T>> {
 
 	/**
 	 * Implementing classes of this interface represent navigable association
@@ -22,7 +22,7 @@ public interface Navigability {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface Navigable extends Navigability {
+	public interface Navigable extends Navigability<Navigable> {
 	}
 
 	/**
@@ -35,7 +35,7 @@ public interface Navigability {
 	 * @author Gabor Ferenc Kovacs
 	 *
 	 */
-	public interface NonNavigable extends Navigability {
+	public interface NonNavigable extends Navigability<NonNavigable> {
 	}
 
 }


### PR DESCRIPTION
(Had no issue about it, just an improvement.)