### PR TITLE
Fix XtxtUML tests

### DIFF
--- a/tests/hu.elte.txtuml.xtxtuml.tests/META-INF/MANIFEST.MF
+++ b/tests/hu.elte.txtuml.xtxtuml.tests/META-INF/MANIFEST.MF
@@ -7,7 +7,8 @@ Bundle-SymbolicName: hu.elte.txtuml.xtxtuml.tests
 Fragment-Host: hu.elte.txtuml.xtxtuml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,
+ org.eclipse.jdt.core,
+ org.eclipse.ui.workbench,
  org.eclipse.xtext.junit4,
  org.eclipse.xtext.xbase.junit,
- org.eclipse.ui.workbench,
  hu.elte.txtuml.xtxtuml.ui

--- a/tests/hu.elte.txtuml.xtxtuml.tests/pom.xml
+++ b/tests/hu.elte.txtuml.xtxtuml.tests/pom.xml
@@ -27,18 +27,6 @@
 				<groupId>org.eclipse.xtend</groupId>
 				<artifactId>xtend-maven-plugin</artifactId>
 			</plugin>
-
-	<!-- TODO: Remove the following block if tests are fixed!!! -->
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<configuration>
-					<skipTests>true</skipTests>
-				</configuration>
-			</plugin>
-	<!-- TODO: Remove the previous block if tests are fixed!!! -->
-
 		</plugins>
 	</build>
 

--- a/tests/hu.elte.txtuml.xtxtuml.tests/src/hu/elte/txtuml/xtxtuml/tests/XtxtUMLCompilerTest.xtend
+++ b/tests/hu.elte.txtuml.xtxtuml.tests/src/hu/elte/txtuml/xtxtuml/tests/XtxtUMLCompilerTest.xtend
@@ -22,12 +22,12 @@ class XtxtUMLCompilerTest {
 	@Inject extension CompilationTestHelper
 	
 	@Test
-	def test() {
+	def testEmptyModel() {
 		'''
 			model M {
 			}
 		'''.assertCompilesTo('''
-			import hu.elte.txtuml.api.Model;
+			import hu.elte.txtuml.api.model.Model;
 
 			@SuppressWarnings("all")
 			public class M extends Model {

--- a/tests/hu.elte.txtuml.xtxtuml.tests/src/hu/elte/txtuml/xtxtuml/tests/XtxtUMLParserTest.xtend
+++ b/tests/hu.elte.txtuml.xtxtuml.tests/src/hu/elte/txtuml/xtxtuml/tests/XtxtUMLParserTest.xtend
@@ -29,7 +29,7 @@ class XtxtUMLParserTest {
 	// Test methods
 	
 	@Test
-	def testDuplicates() {
+	def testEmptyModel() {
 		'''	
 			model M {}
 		'''.parse.assertNoErrors;


### PR DESCRIPTION
This is intended to fix #152. The previous implementation of XtxtUML tests failed due to a missing dependency on `org.eclipse.jdt.core`.