### PR TITLE
Getting rid of moka

### DIFF
--- a/features/hu.elte.txtuml.feature/feature.xml
+++ b/features/hu.elte.txtuml.feature/feature.xml
@@ -111,7 +111,6 @@ This Agreement is governed by the laws of the State of New York and the intellec
    <requires>
       <import feature="org.eclipse.emf.sdk" version="2.11.1.v20150806-0404"/>
       <import feature="org.eclipse.papyrus.sdk.feature" version="1.1.2.201509161440"/>
-      <import feature="org.eclipse.papyrus.extra.moka.feature" version="1.1.2.201509161524"/>
       <import feature="org.eclipse.xtext.runtime" version="2.8.4.v201508050135"/>
       <import feature="org.eclipse.xtext.xbase" version="2.8.4.v201508050135"/>
       <import feature="org.eclipse.xtext.xbase.lib" version="2.8.4.v201508050135"/>

--- a/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
+++ b/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.launching,
  org.eclipse.debug.ui,
  org.eclipse.jdt.debug.ui,
- org.eclipse.papyrus.moka.ui;bundle-version="1.1.0",
  org.eclipse.emf.ecore,
  hu.elte.txtuml.export.uml2;bundle-version="0.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
+++ b/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.debug.ui,
  org.eclipse.emf.ecore,
  org.eclipse.papyrus.infra.services.markerlistener,
+ org.eclipse.papyrus.infra.gmfdiag.css,
  hu.elte.txtuml.export.uml2;bundle-version="0.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
+++ b/plugins/hu.elte.txtuml.diagnostics/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.debug.ui,
  org.eclipse.jdt.debug.ui,
  org.eclipse.emf.ecore,
+ org.eclipse.papyrus.infra.services.markerlistener,
  hu.elte.txtuml.export.uml2;bundle-version="0.3.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/plugins/hu.elte.txtuml.diagnostics/build.properties
+++ b/plugins/hu.elte.txtuml.diagnostics/build.properties
@@ -2,4 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               css/

--- a/plugins/hu.elte.txtuml.diagnostics/css/txtUMLAnimation.css
+++ b/plugins/hu.elte.txtuml.diagnostics/css/txtUMLAnimation.css
@@ -1,0 +1,6 @@
+:txtumlanimated{
+	lineColor: #c00000;
+	lineWidth: 3px;
+	fillColor: #c00000;
+	bold: true;
+}

--- a/plugins/hu.elte.txtuml.diagnostics/plugin.xml
+++ b/plugins/hu.elte.txtuml.diagnostics/plugin.xml
@@ -19,4 +19,31 @@
       </launchConfigurationTabGroup>
    </extension>
 
+   <extension
+         point="org.eclipse.papyrus.infra.gmfdiag.css.markertopseudoselectormappingprovider">
+      <provider
+            class="hu.elte.txtuml.diagnostics.animation.AnimationMarkerToPseudoSelectorMappingProvider">
+      </provider>
+   </extension>
+   <extension
+         id="hu.elte.txtuml.diagnostics.animation.animatedmarker"
+         name="ANIMATED MARKER"
+         point="org.eclipse.core.resources.markers">
+      <super
+            type="org.eclipse.papyrus.modelmarker">
+      </super>
+      <persistent
+            value="false">
+      </persistent>
+   </extension>
+   <extension
+         point="org.eclipse.papyrus.infra.gmfdiag.css.theme">
+      <themeContribution
+            id="org.eclipse.papyrus.css.papyrus_theme">
+         <stylesheet
+               stylesheetPath="css/txtUMLAnimation.css">
+         </stylesheet>
+      </themeContribution>
+   </extension>
+
 </plugin>

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/AnimationConfig.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/AnimationConfig.java
@@ -1,0 +1,11 @@
+package hu.elte.txtuml.diagnostics.animation;
+
+/**
+ * Configuration and IDs for animation related stuff
+ * @author gerazo
+ */
+public class AnimationConfig {
+	static final int ANIMATION_TIMER = 1000;
+	static final String TXTUML_ANIMATION_PSEUDO_SELECTOR = "txtumlanimated";
+	static final String TXTUML_ANIMATION_MARKER_ID = "hu.elte.txtuml.diagnostics.animation.animatedmarker";
+}

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/AnimationMarkerToPseudoSelectorMappingProvider.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/AnimationMarkerToPseudoSelectorMappingProvider.java
@@ -1,0 +1,26 @@
+package hu.elte.txtuml.diagnostics.animation;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.eclipse.papyrus.infra.gmfdiag.css.service.IMarkerToPseudoSelectorMappingProvider;
+
+/**
+ * The mapping from marker kind to the selector in CSS file
+ * @author gerazo
+ */
+public class AnimationMarkerToPseudoSelectorMappingProvider implements IMarkerToPseudoSelectorMappingProvider {
+	private Map<String, String> mappings;
+	
+	public AnimationMarkerToPseudoSelectorMappingProvider() {}
+	
+	@Override
+	public Map<String, String> getMappings() {
+		if (mappings == null) {
+			mappings = new TreeMap<String, String>();
+			mappings.put(AnimationConfig.TXTUML_ANIMATION_MARKER_ID, AnimationConfig.TXTUML_ANIMATION_PSEUDO_SELECTOR);
+		}
+		return mappings;
+	}
+
+}

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/Animator.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/Animator.java
@@ -26,12 +26,6 @@ import org.eclipse.papyrus.infra.services.markerlistener.PapyrusMarkerAdapter;
  * @author gerazo
  */
 public class Animator {
-	private static final int ANIMATION_TIMER = 1000;
-	
-	// Warning! This is fragile as it was changed to "org.eclipse.papyrus.moka.animation.animatedmarker" in more recent versions
-	private static final String MOKA_ANIMATION_MARKER_ID = "org.eclipse.papyrus.moka.ui.animationmarker";
-
-	
 	private InstanceRegister instanceRegister;
 	private ModelMapper modelMapper;
 	private Map<String, UniqueInstance> classNameToAnimatedInstance = new HashMap<String, UniqueInstance>();
@@ -75,7 +69,7 @@ public class Animator {
 		}
 
 		try {
-			Thread.sleep(ANIMATION_TIMER);
+			Thread.sleep(AnimationConfig.ANIMATION_TIMER);
 		} catch (InterruptedException ex) {}
 	}
 		
@@ -102,7 +96,7 @@ public class Animator {
 		if (resource != null && resource.exists()) {
 			IMarker imarker = null;
 			try {
-				imarker = resource.createMarker(MOKA_ANIMATION_MARKER_ID);
+				imarker = resource.createMarker(AnimationConfig.TXTUML_ANIMATION_MARKER_ID);
 				imarker.setAttribute(EValidator.URI_ATTRIBUTE, EcoreUtil.getURI(eobject).toString());
 			} catch (CoreException e) {
 				e.printStackTrace();

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/Animator.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/animation/Animator.java
@@ -1,10 +1,13 @@
-package hu.elte.txtuml.diagnostics.session;
+package hu.elte.txtuml.diagnostics.animation;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import hu.elte.txtuml.api.diagnostics.protocol.MessageType;
 import hu.elte.txtuml.api.diagnostics.protocol.ModelEvent;
+import hu.elte.txtuml.diagnostics.session.InstanceRegister;
+import hu.elte.txtuml.diagnostics.session.ModelMapper;
+import hu.elte.txtuml.diagnostics.session.UniqueInstance;
 
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -22,7 +25,7 @@ import org.eclipse.papyrus.infra.services.markerlistener.PapyrusMarkerAdapter;
  * Animates diagrams
  * @author gerazo
  */
-class Animator {
+public class Animator {
 	private static final int ANIMATION_TIMER = 1000;
 	
 	// Warning! This is fragile as it was changed to "org.eclipse.papyrus.moka.animation.animatedmarker" in more recent versions
@@ -35,12 +38,12 @@ class Animator {
 	private Map<String, EObject> classNameToAnimatedElement = new HashMap<String, EObject>();
 	private Map<EObject, IPapyrusMarker> eobjectToMarker = new HashMap<EObject, IPapyrusMarker>();
 	
-	Animator(InstanceRegister instanceRegister, ModelMapper modelMapper) {
+	public Animator(InstanceRegister instanceRegister, ModelMapper modelMapper) {
 		this.instanceRegister = instanceRegister;
 		this.modelMapper = modelMapper;
 	}
 	
-	void dispose() {
+	public void dispose() {
 		removeAllAnimationMarkers();
 		eobjectToMarker = null;
 		classNameToAnimatedElement.clear();
@@ -51,7 +54,7 @@ class Animator {
 		instanceRegister = null;
 	}
 	
-	void animateEvent(ModelEvent event) {
+	public void animateEvent(ModelEvent event) {
 		if (event.messageType == MessageType.PROCESSING_SIGNAL) {
 			return;
 		}

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
@@ -42,7 +42,6 @@ class Animator {
 	
 	void dispose() {
 		removeAllAnimationMarkers();
-		eobjectToMarker.clear();
 		eobjectToMarker = null;
 		classNameToAnimatedElement.clear();
 		classNameToAnimatedElement = null;
@@ -86,8 +85,9 @@ class Animator {
 	
 	private void removeAllAnimationMarkers() {
 		for (EObject eobject : eobjectToMarker.keySet()) {
-			removeAnimationMarker(eobject);
+			removeAnimationMarker(eobject, false);
 		}
+		eobjectToMarker.clear();
 	}
 	
 	private void addAnimationMarker(EObject eobject) {
@@ -111,7 +111,7 @@ class Animator {
 		}
 	}
 
-	private void removeAnimationMarker(EObject eobject) {
+	private void removeAnimationMarker(EObject eobject, boolean removeFromMap) {
 		IPapyrusMarker marker = eobjectToMarker.get(eobject);
 		if (marker != null) {
 			try {
@@ -119,8 +119,13 @@ class Animator {
 			} catch (CoreException e) {
 				e.printStackTrace();
 			}
-			eobjectToMarker.remove(eobject);
+			if (removeFromMap) {
+				eobjectToMarker.remove(eobject);
+			}
 		}
 	}
 
+	private void removeAnimationMarker(EObject eobject) {
+		removeAnimationMarker(eobject, true);
+	}
 }

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
@@ -24,7 +24,9 @@ import org.eclipse.papyrus.infra.services.markerlistener.PapyrusMarkerAdapter;
  */
 class Animator {
 	private static final int ANIMATION_TIMER = 1000;
-	private static final String ANIMATED_MARKER_ID = "hu.elte.txtuml.diagnostics.animatedmarker";
+	
+	// Warning! This is fragile as it was changed to "org.eclipse.papyrus.moka.animation.animatedmarker" in more recent versions
+	private static final String MOKA_ANIMATION_MARKER_ID = "org.eclipse.papyrus.moka.ui.animationmarker";
 
 	
 	private InstanceRegister instanceRegister;
@@ -89,23 +91,21 @@ class Animator {
 	}
 	
 	private void addAnimationMarker(EObject eobject) {
-		Map<String, String> attributes = new HashMap<String, String>();
-		attributes.put(EValidator.URI_ATTRIBUTE, EcoreUtil.getURI(eobject).toString());
 		IResource resource = null;
 		IWorkspace workspace = ResourcesPlugin.getWorkspace(); 
 		if (workspace != null) {
 			resource = workspace.getRoot().getFile(new Path(eobject.eResource().getURI().toPlatformString(true)));
 		}
-		if (resource != null) {
+		if (resource != null && resource.exists()) {
 			IMarker imarker = null;
 			try {
-				imarker = resource.createMarker(ANIMATED_MARKER_ID);
-				imarker.setAttributes(attributes);
+				imarker = resource.createMarker(MOKA_ANIMATION_MARKER_ID);
+				imarker.setAttribute(EValidator.URI_ATTRIBUTE, EcoreUtil.getURI(eobject).toString());
 			} catch (CoreException e) {
 				e.printStackTrace();
 			}
 			if (imarker != null) {
-				IPapyrusMarker marker = PapyrusMarkerAdapter.wrap(eobject.eResource(), imarker, attributes);
+				IPapyrusMarker marker = PapyrusMarkerAdapter.wrap(eobject.eResource(), imarker);
 				eobjectToMarker.put(eobject, marker);
 			}
 		}

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/Animator.java
@@ -6,8 +6,17 @@ import java.util.Map;
 import hu.elte.txtuml.api.diagnostics.protocol.MessageType;
 import hu.elte.txtuml.api.diagnostics.protocol.ModelEvent;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.papyrus.moka.ui.presentation.AnimationUtils;
+import org.eclipse.emf.ecore.EValidator;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.papyrus.infra.services.markerlistener.IPapyrusMarker;
+import org.eclipse.papyrus.infra.services.markerlistener.PapyrusMarkerAdapter;
 
 /**
  * Animates diagrams
@@ -15,27 +24,28 @@ import org.eclipse.papyrus.moka.ui.presentation.AnimationUtils;
  */
 class Animator {
 	private static final int ANIMATION_TIMER = 1000;
+	private static final String ANIMATED_MARKER_ID = "hu.elte.txtuml.diagnostics.animatedmarker";
+
 	
 	private InstanceRegister instanceRegister;
 	private ModelMapper modelMapper;
-	private AnimationUtils animationUtils;
 	private Map<String, UniqueInstance> classNameToAnimatedInstance = new HashMap<String, UniqueInstance>();
 	private Map<String, EObject> classNameToAnimatedElement = new HashMap<String, EObject>();
+	private Map<EObject, IPapyrusMarker> eobjectToMarker = new HashMap<EObject, IPapyrusMarker>();
 	
 	Animator(InstanceRegister instanceRegister, ModelMapper modelMapper) {
 		this.instanceRegister = instanceRegister;
 		this.modelMapper = modelMapper;
-		animationUtils = AnimationUtils.getInstance();
-		AnimationUtils.init();
 	}
 	
 	void dispose() {
+		removeAllAnimationMarkers();
+		eobjectToMarker.clear();
+		eobjectToMarker = null;
 		classNameToAnimatedElement.clear();
 		classNameToAnimatedElement = null;
 		classNameToAnimatedInstance.clear();
 		classNameToAnimatedInstance = null;
-		animationUtils.removeAllAnimationMarker();
-		animationUtils = null;
 		modelMapper = null;
 		instanceRegister = null;
 	}
@@ -56,9 +66,8 @@ class Animator {
 		removeMarkerFromClass(event.modelClassName);
 		// animationUtils.removeAllAnimationMarker();
 		if (eobject != null) {
-			animationUtils.addAnimationMarker(eobject);
+			addAnimationMarker(eobject);
 			classNameToAnimatedElement.put(event.modelClassName, eobject);
-			
 		}
 
 		try {
@@ -69,7 +78,48 @@ class Animator {
 	private void removeMarkerFromClass(String modelClassName) {
 		EObject animatedObj = classNameToAnimatedElement.get(modelClassName); 
 		if(animatedObj != null) {
-			animationUtils.removeAnimationMarker(animatedObj);
+			removeAnimationMarker(animatedObj);
+		}
+	}
+	
+	private void removeAllAnimationMarkers() {
+		for (EObject eobject : eobjectToMarker.keySet()) {
+			removeAnimationMarker(eobject);
+		}
+	}
+	
+	private void addAnimationMarker(EObject eobject) {
+		Map<String, String> attributes = new HashMap<String, String>();
+		attributes.put(EValidator.URI_ATTRIBUTE, EcoreUtil.getURI(eobject).toString());
+		IResource resource = null;
+		IWorkspace workspace = ResourcesPlugin.getWorkspace(); 
+		if (workspace != null) {
+			resource = workspace.getRoot().getFile(new Path(eobject.eResource().getURI().toPlatformString(true)));
+		}
+		if (resource != null) {
+			IMarker imarker = null;
+			try {
+				imarker = resource.createMarker(ANIMATED_MARKER_ID);
+				imarker.setAttributes(attributes);
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+			if (imarker != null) {
+				IPapyrusMarker marker = PapyrusMarkerAdapter.wrap(eobject.eResource(), imarker, attributes);
+				eobjectToMarker.put(eobject, marker);
+			}
+		}
+	}
+
+	private void removeAnimationMarker(EObject eobject) {
+		IPapyrusMarker marker = eobjectToMarker.get(eobject);
+		if (marker != null) {
+			try {
+				marker.delete();
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+			eobjectToMarker.remove(eobject);
 		}
 	}
 

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/DiagnosticsPlugin.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/DiagnosticsPlugin.java
@@ -5,6 +5,7 @@ import hu.elte.txtuml.api.diagnostics.protocol.MessageType;
 import hu.elte.txtuml.api.diagnostics.protocol.ModelEvent;
 import hu.elte.txtuml.diagnostics.Activator;
 import hu.elte.txtuml.diagnostics.PluginLogWrapper;
+import hu.elte.txtuml.diagnostics.animation.Animator;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/InstanceRegister.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/InstanceRegister.java
@@ -19,7 +19,7 @@ import hu.elte.txtuml.diagnostics.PluginLogWrapper;
  * Analyzes events for errors, keeps track of service and class instances
  * @author gerazo
  */
-class InstanceRegister {
+public class InstanceRegister {
 	// Usually only 1 or 2 instances will be in this container so a
 	// TreeSet performs better as its memory is more compact than HashSet's
 	private Set<Integer> aliveServiceInstances = new TreeSet<>();
@@ -44,7 +44,7 @@ class InstanceRegister {
 		aliveServiceInstances = null;
 	}
 	
-	UniqueInstance getInstance(String classInstanceID, int serviceInstanceID) {
+	public UniqueInstance getInstance(String classInstanceID, int serviceInstanceID) {
 		return aliveClassInstances.get(new UniqueInstance(classInstanceID, serviceInstanceID));
 	}
 	

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/ModelMapper.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/ModelMapper.java
@@ -24,7 +24,7 @@ import hu.elte.txtuml.export.uml2.mapping.ModelMapProvider;
  * Keeps track of model mappings
  * @author gerazo
  */
-class ModelMapper {
+public class ModelMapper {
 	private static final String MAPPING_FILE_EXTENSION = ModelMapProvider.MAPPING_FILE_EXTENSION;
 	private static final String MAPPING_FILE_EXTENSION_TOKEN = "." + MAPPING_FILE_EXTENSION;
 	private static final String MAPPING_DIRECTORY_PATH =
@@ -71,7 +71,7 @@ class ModelMapper {
 		mappingFileNameToMapProvider = null;
 	}
 	
-	EObject getEObjectForModelAndElement(String modelClassName, String elementClassName) {
+	public EObject getEObjectForModelAndElement(String modelClassName, String elementClassName) {
 		ModelMapProvider modelMapProvider = null;
 		Map.Entry<String, ModelMapProvider> entry = mappingFileNameToMapProvider.floorEntry(modelClassName);
 		// We do depend heavily on the fact that the mapping file name begins

--- a/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/UniqueInstance.java
+++ b/plugins/hu.elte.txtuml.diagnostics/src/hu/elte/txtuml/diagnostics/session/UniqueInstance.java
@@ -13,7 +13,7 @@ import hu.elte.txtuml.diagnostics.PluginLogWrapper;
  * object in it.
  * @author gerazo
  */
-class UniqueInstance {
+public class UniqueInstance {
 	// unique ID
 	final String classInstanceID;
 	final int serviceInstanceID;

--- a/plugins/hu.elte.txtuml.xtxtuml/.launch/Launch Runtime Eclipse.launch
+++ b/plugins/hu.elte.txtuml.xtxtuml/.launch/Launch Runtime Eclipse.launch
@@ -22,7 +22,7 @@
 <listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
 </listAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl}"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms40m -Xmx512m -XX:MaxPermSize=256m"/>
 <stringAttribute key="pde.version" value="3.3"/>

--- a/releng/hu.elte.txtuml.target/mirrors.target
+++ b/releng/hu.elte.txtuml.target/mirrors.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="mirrors" sequenceNumber="13">
+<target name="mirrors" sequenceNumber="14">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.feature.group" version="3.11.1.v20150904-0015"/>
@@ -16,10 +16,6 @@
 			<unit id="org.eclipse.xtext.xbase.feature.group" version="2.8.4.v201508050135"/>
 			<unit id="org.eclipse.xtext.xtext.ui.feature.group" version="2.8.4.v201508050135"/>
 			<repository location="http://mextest.inf.elte.hu/updates/mirrors/eclipse-mars"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.papyrus.extra.moka.feature.feature.group" version="1.1.2.201509161524"/>
-			<repository location="http://mextest.inf.elte.hu/updates/mirrors/papyrus-mars"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.powermock.mockito-junit.feature.feature.group" version="1.5.6.0"/>

--- a/releng/hu.elte.txtuml.target/release.target
+++ b/releng/hu.elte.txtuml.target/release.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="release" sequenceNumber="6">
+<target name="release" sequenceNumber="7">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.eclipse.jdt.feature.group" version="3.11.1.v20150904-0015"/>
@@ -16,10 +16,6 @@
 			<unit id="org.eclipse.xtext.xbase.feature.group" version="2.8.4.v201508050135"/>
 			<unit id="org.eclipse.xtext.xtext.ui.feature.group" version="2.8.4.v201508050135"/>
 			<repository location="http://download.eclipse.org/releases/mars/201510021000"/>
-		</location>
-		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<unit id="org.eclipse.papyrus.extra.moka.feature.feature.group" version="1.1.2.201509161524"/>
-			<repository location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/mars/1.1.2/extra"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="org.powermock.mockito-junit.feature.feature.group" version="1.5.6.0"/>

--- a/releng/hu.elte.txtuml.updatesite/associate.sites.mirrors.properties
+++ b/releng/hu.elte.txtuml.updatesite/associate.sites.mirrors.properties
@@ -1,3 +1,5 @@
+# WARNING: this file is currently unused, see pom.xml
+
 # comma-separated list of associate update sites
 # - mirror sites are also added for faster installation times
 associate.sites=http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/mars/extra/,\

--- a/releng/hu.elte.txtuml.updatesite/associate.sites.release.properties
+++ b/releng/hu.elte.txtuml.updatesite/associate.sites.release.properties
@@ -1,3 +1,5 @@
+# WARNING: this file is currently unused, see pom.xml
+
 # comma-separated list of associate update sites
 associate.sites=http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/mars/extra/
 

--- a/releng/hu.elte.txtuml.updatesite/pom.xml
+++ b/releng/hu.elte.txtuml.updatesite/pom.xml
@@ -32,7 +32,8 @@
 				</configuration>
 			</plugin>
 
-			<!-- Modify update site metadata and inject associate sites -->
+			<!-- Currently we do not use any associate sites. Re-enable this section when it is needed again. -->
+			<!-- Modify update site metadata and inject associate sites
 			<plugin>
 				<artifactId>maven-antrun-plugin</artifactId>
 				<version>1.8</version>
@@ -68,6 +69,7 @@
 					</execution>
 				</executions>
 			</plugin>
+			-->
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
Finally getting rid of Moka. Please review!
The new version uses our own CSS to parametrize the animation outlook.
See also the stylesheet itself: hu.elte.txtuml.diagnostics/css/txtUMLAnimation.css
There are multiple possibilities in it which do work. We should decide and fine tune according to which looks cooler. (for example the bold text sometimes looks weird with ill formed diagrams). Please review this as well! @kmate @devaigergely81 @kovacsgabor @GregoBalu @dobreffandras @djnemeth 