### PR TITLE
Fix handling of omitted association end multiplicity in XtxtUML

### DIFF
--- a/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/jvmmodel/XtxtUMLJvmModelInferrer.xtend
+++ b/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/jvmmodel/XtxtUMLJvmModelInferrer.xtend
@@ -334,7 +334,9 @@ class XtxtUMLJvmModelInferrer extends AbstractModelInferrer {
 
 		val optionalHidden = if(notNavigable) "Hidden" else ""
 		var Pair<Integer, Integer> explicitMultiplicities = null
-		val apiBoundTypeName = if (multiplicity.any) // *
+		val apiBoundTypeName = if (multiplicity == null) // omitted
+				"One"
+			else if (multiplicity.any) // *
 				"Many"
 			else if (!multiplicity.upperSet) { // <lower> (exact)
 				if (multiplicity.lower == 1)


### PR DESCRIPTION
As it has been reported in #241, if an association end multiplicity was omitted in XtxtUML, the incorrect type inference lead to faulty JtxtUML code generation. This is now fixed by inferring `One` as default multiplicity.