### PR TITLE
fix for the reflexive associations problem

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/api/DiagramElementsModifier.java
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/api/DiagramElementsModifier.java
@@ -100,24 +100,22 @@ public class DiagramElementsModifier {
 	}
 	
 	/**
-	 * Sets the BendPoints of a connection. (Starting point and Ending points are not BendPoints)
+	 * Sets the points of a connection.
 	 * @param connection - The connection
-	 * @param bendpoints - The BendPoints
+	 * @param bendpoints - Start, end and bending points
 	 */
-	public static void setConnectionBendpoints(ConnectionNodeEditPart connection, List<Point> bendpoints){
+	public static void setConnectionPoints(ConnectionNodeEditPart connection, List<Point> bendpoints){
 		TransactionalEditingDomain editingDomain = connection.getEditingDomain();
 		SetConnectionBendpointsCommand cmd = new SetConnectionBendpointsCommand(editingDomain);
 		cmd.setEdgeAdapter(new EObjectAdapter(connection.getNotationView()));
 		
-		Point sourceRef = connection.getConnectionFigure().getSourceAnchor().getReferencePoint();
-		Point targetRef = connection.getConnectionFigure().getTargetAnchor().getReferencePoint();
+		Point sourceRef = bendpoints.get(0);
+		Point targetRef = bendpoints.get(bendpoints.size()-1);
 		PointList pointList = new PointList();
 		
-		pointList.addPoint(sourceRef);
 		for(Point bendpoint: bendpoints){
 			pointList.addPoint(bendpoint);
 		}
-		pointList.addPoint(targetRef);
 		
 		cmd.setNewPointList(pointList, sourceRef, targetRef);
 		Command proxy =  new ICommandProxy(cmd);

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/elementsarrangers/txtumllayout/AbstractDiagramElementsTxtUmlArranger.java
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/elementsarrangers/txtumllayout/AbstractDiagramElementsTxtUmlArranger.java
@@ -127,12 +127,9 @@ public abstract class  AbstractDiagramElementsTxtUmlArranger extends AbstractDia
 						
 			        	String anchor_start = getAnchor(source.getTopLeft(), route.get(0), source.width, source.height);
 			        	String anchor_end = getAnchor(target.getTopLeft(), route.get(route.size()-1), target.width, target.height);
-			        	route.remove(0);
-			        	route.remove(route.size()-1);
-			        	connection.getSource();
 			        	
 			        	DiagramElementsModifier.setConnectionAnchors(connection, anchor_start, anchor_end);
-			        	DiagramElementsModifier.setConnectionBendpoints(connection, route);
+			        	DiagramElementsModifier.setConnectionPoints(connection, route);
 					}
 		});
 	}

--- a/dev/tests/hu.elte.txtuml.export.papyrus.tests/src/hu/elte/txtuml/export/papyrus/api/tests/DiagramElementsModifierTest.java
+++ b/dev/tests/hu.elte.txtuml.export.papyrus.tests/src/hu/elte/txtuml/export/papyrus/api/tests/DiagramElementsModifierTest.java
@@ -315,7 +315,7 @@ public class DiagramElementsModifierTest {
 
 		List<Point> bendpointslist = Arrays.asList(new Point(10, 10),
 				new Point(150, 200), new Point(400, 300));
-		DiagramElementsModifier.setConnectionBendpoints(assoc, bendpointslist);
+		DiagramElementsModifier.setConnectionPoints(assoc, bendpointslist);
 	}
 
 	/**


### PR DESCRIPTION
This fixes the problem of misplaced reflexive association lines. The problem was the following: The original implementation of the `setConnectionBendpoints` function tried to restore the start and endpoint of a line from the anchor points. For some reason this works fine for non-reflexive lines, but gives (0,0) points for reflexive ones, which triggers Papyrus to move (and to distort) the whole line.

@dobreffandras, please review this branch! If you think its OK, please merge it to master and from there to the layout-sm-diagrams branch to see if the distorted lines of state machines could be resolved similarly.