### PR TITLE
Uml export action code improvements

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/wizardz/TxtUMLToCppGovernor.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/wizardz/TxtUMLToCppGovernor.java
@@ -41,8 +41,7 @@ class TxtUMLToCppGovernor {
 
 		Model model;
 		try {
-			ExportMode exportMode = testing ? ExportMode.ExportActionsErrorHandling : ExportMode.ExportActionsPedantic;
-			model = TxtUMLToUML2.exportModel(txtUMLProject, txtUMLModel, umlFilesFolder, exportMode);
+			model = TxtUMLToUML2.exportModel(txtUMLProject, txtUMLModel, umlFilesFolder, ExportMode.ExportActionsPedantic);
 		} catch (Exception e) {
 			if (!testing) {
 				Dialogs.errorMsgb("txtUML export Error", e.getClass() + ":" + System.lineSeparator() + e.getMessage(),

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
@@ -2,16 +2,19 @@ package hu.elte.txtuml.export.uml2
 
 import hu.elte.txtuml.export.uml2.activity.MethodActivityExporter
 import hu.elte.txtuml.export.uml2.activity.SMActivityExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.AutoboxExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.CreateActionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.CreateLinkActionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.DeleteActionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.GetSignalExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.IgnoredAPICallExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.LogActionExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.PrimitiveToStringExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.ReadLinkActionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.SelectionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.SendActionExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.StartActionExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.ToStringExporter
 import hu.elte.txtuml.export.uml2.activity.apicalls.UnlinkActionExporter
 import hu.elte.txtuml.export.uml2.activity.expression.APISuperCtorCallExporter
 import hu.elte.txtuml.export.uml2.activity.expression.AssignExporter
@@ -19,6 +22,7 @@ import hu.elte.txtuml.export.uml2.activity.expression.BinaryOperatorExporter
 import hu.elte.txtuml.export.uml2.activity.expression.BooleanLiteralExporter
 import hu.elte.txtuml.export.uml2.activity.expression.CharacterLiteralExporter
 import hu.elte.txtuml.export.uml2.activity.expression.ConstructorCallExporter
+import hu.elte.txtuml.export.uml2.activity.expression.EqualityExporter
 import hu.elte.txtuml.export.uml2.activity.expression.MethodCallExporter
 import hu.elte.txtuml.export.uml2.activity.expression.NameFieldAccessExporter
 import hu.elte.txtuml.export.uml2.activity.expression.NullLiteralExporter
@@ -33,6 +37,7 @@ import hu.elte.txtuml.export.uml2.activity.expression.StringLiteralExporter
 import hu.elte.txtuml.export.uml2.activity.expression.SuperCallExporter
 import hu.elte.txtuml.export.uml2.activity.expression.SuperCtorCallExporter
 import hu.elte.txtuml.export.uml2.activity.expression.ThisExporter
+import hu.elte.txtuml.export.uml2.activity.expression.UnequalityExporter
 import hu.elte.txtuml.export.uml2.activity.expression.VariableDeclarationExpressionExporter
 import hu.elte.txtuml.export.uml2.activity.expression.VariableExpressionExporter
 import hu.elte.txtuml.export.uml2.activity.statement.BlockExporter
@@ -58,8 +63,10 @@ import hu.elte.txtuml.export.uml2.structural.DataTypeExporter
 import hu.elte.txtuml.export.uml2.structural.DefaultConstructorBodyExporter
 import hu.elte.txtuml.export.uml2.structural.DefaultConstructorExporter
 import hu.elte.txtuml.export.uml2.structural.FieldExporter
+import hu.elte.txtuml.export.uml2.structural.InPortExporter
 import hu.elte.txtuml.export.uml2.structural.InterfaceExporter
 import hu.elte.txtuml.export.uml2.structural.OperationExporter
+import hu.elte.txtuml.export.uml2.structural.OutPortExporter
 import hu.elte.txtuml.export.uml2.structural.PackageExporter
 import hu.elte.txtuml.export.uml2.structural.ParameterExporter
 import hu.elte.txtuml.export.uml2.structural.PortExporter
@@ -109,11 +116,6 @@ import org.eclipse.uml2.uml.ExecutableNode
 import org.eclipse.uml2.uml.PackageableElement
 import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.uml2.uml.Type
-import hu.elte.txtuml.export.uml2.structural.InPortExporter
-import hu.elte.txtuml.export.uml2.structural.OutPortExporter
-import hu.elte.txtuml.export.uml2.activity.apicalls.PrimitiveToStringExporter
-import hu.elte.txtuml.export.uml2.activity.apicalls.ToStringExporter
-import hu.elte.txtuml.export.uml2.activity.apicalls.AutoboxExporter
 
 /** An exporter is able to fully or partially export a given element. 
  * Partial export only creates the UML object itself, while full export also creates its contents.
@@ -262,7 +264,7 @@ abstract class Exporter<S, A, R extends Element> extends BaseExporter<S, A, R> {
 			ThisExpression:
 				#[new ThisExporter(this)]
 			InfixExpression:
-				#[new BinaryOperatorExporter(this)]
+				#[new EqualityExporter(this), new UnequalityExporter(this), new BinaryOperatorExporter(this)]
 			PrefixExpression:
 				#[new PrefixPlusExporter(this), new PrefixOperatorExporter(this)]
 			PostfixExpression:

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
@@ -116,6 +116,7 @@ import org.eclipse.uml2.uml.ExecutableNode
 import org.eclipse.uml2.uml.PackageableElement
 import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.uml2.uml.Type
+import hu.elte.txtuml.export.uml2.activity.apicalls.CountExporter
 
 /** An exporter is able to fully or partially export a given element. 
  * Partial export only creates the UML object itself, while full export also creates its contents.
@@ -236,6 +237,7 @@ abstract class Exporter<S, A, R extends Element> extends BaseExporter<S, A, R> {
 					new DeleteActionExporter(this),
 					new StartActionExporter(this),
 					new SelectionExporter(this),
+					new CountExporter(this),
 					new GetSignalExporter(this),
 					new IgnoredAPICallExporter(this)
 				]

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/Exporter.xtend
@@ -111,6 +111,9 @@ import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.uml2.uml.Type
 import hu.elte.txtuml.export.uml2.structural.InPortExporter
 import hu.elte.txtuml.export.uml2.structural.OutPortExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.PrimitiveToStringExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.ToStringExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.AutoboxExporter
 
 /** An exporter is able to fully or partially export a given element. 
  * Partial export only creates the UML object itself, while full export also creates its contents.
@@ -218,6 +221,9 @@ abstract class Exporter<S, A, R extends Element> extends BaseExporter<S, A, R> {
 				#[new BlockExporter(this)]
 			MethodInvocation:
 				#[
+					new ToStringExporter(this),
+					new PrimitiveToStringExporter(this),
+					new AutoboxExporter(this),
 					new MethodCallExporter(this),
 					new ReadLinkActionExporter(this),
 					new LogActionExporter(this),

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/ActionExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/ActionExporter.xtend
@@ -31,6 +31,7 @@ import hu.elte.txtuml.export.uml2.activity.statement.LoopInitExporter
 import org.eclipse.jdt.core.dom.ForStatement
 import hu.elte.txtuml.export.uml2.activity.statement.LoopUpdateExporter
 import hu.elte.txtuml.export.uml2.activity.statement.LoopConditionExporter
+import org.eclipse.uml2.uml.TestIdentityAction
 
 /**
  * Base class for all exporters on the statement-expression level.
@@ -83,6 +84,8 @@ abstract class ActionExporter<S, R extends Element> extends Exporter<S, S, R> {
 	}
 
 	def dispatch OutputPin result(ReadVariableAction node) { node.result }
+	
+	def dispatch OutputPin result(TestIdentityAction node) { node.result }
 
 	def dispatch OutputPin result(ReadSelfAction node) { node.result }
 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/PrepareBlockExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/PrepareBlockExporter.xtend
@@ -15,7 +15,7 @@ class PrepareBlockExporter extends ControlExporter<Block, SequenceNode> {
 	override create(Block access) { factory.createSequenceNode }
 
 	override exportContents(Block source) {
-		result.activity.specification?.ownedParameters?.forEach [
+		(result.activity.specification?.ownedParameters ?: result.activity.ownedParameters)?.forEach [
 			val paramNode = factory.createActivityParameterNode
 			paramNode.parameter = it
 			paramNode.name = name

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/AutoboxExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/AutoboxExporter.xtend
@@ -1,0 +1,28 @@
+package hu.elte.txtuml.export.uml2.activity.apicalls
+
+import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.export.uml2.activity.statement.ControlExporter
+import org.eclipse.jdt.core.dom.Expression
+import org.eclipse.jdt.core.dom.MethodInvocation
+import org.eclipse.uml2.uml.SequenceNode
+
+class AutoboxExporter extends ControlExporter<MethodInvocation, SequenceNode> {
+
+	private val AUTOBOX_CLASSES = #[Boolean, Byte, Short, Integer, Long, Float, Double].map[canonicalName]
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(MethodInvocation access) {
+		if (AUTOBOX_CLASSES.contains(access.resolveMethodBinding.declaringClass.qualifiedName) &&
+			access.resolveMethodBinding.name == "valueOf" && access.arguments.size == 1)
+			factory.createSequenceNode
+	}
+
+	override exportContents(MethodInvocation source) {
+		val expr = exportExpression(source.arguments.get(0) as Expression)
+		result.name = expr.name
+	}
+	
+}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CountExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CountExporter.xtend
@@ -1,0 +1,27 @@
+package hu.elte.txtuml.export.uml2.activity.apicalls
+
+import hu.elte.txtuml.export.uml2.activity.ActionExporter
+import org.eclipse.jdt.core.dom.MethodInvocation
+import org.eclipse.uml2.uml.CallOperationAction
+import hu.elte.txtuml.export.uml2.BaseExporter
+
+class CountExporter extends ActionExporter<MethodInvocation, CallOperationAction> {
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(MethodInvocation access) {
+		if (isApiMethodInvocation(access.resolveMethodBinding) && access.resolveMethodBinding.name == "count")
+			factory.createCallOperationAction
+	}
+
+	override exportContents(MethodInvocation source) {
+		val expr = source.expression.exportExpression
+		expr.objectFlow(result.createArgument("counted", expr.result.type))
+		result.operation = getImportedOperation("ObjectOperations", "count")
+		result.name = '''count(«expr.name»)'''
+		result.createResult(result.name, integerType)
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CreateActionExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CreateActionExporter.xtend
@@ -54,8 +54,6 @@ class CreateActionExporter extends CreationExporter<MethodInvocation> {
 			new MethodCallExporter(this).createCall(factory.createCallOperationAction,
 				ctor, create, args).storeNode
 		}
-		new MethodCallExporter(this).createCall(factory.createCallOperationAction, ctor,
-			create, args).storeNode
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CreateActionExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/CreateActionExporter.xtend
@@ -3,6 +3,7 @@ package hu.elte.txtuml.export.uml2.activity.apicalls
 import hu.elte.txtuml.export.uml2.BaseExporter
 import hu.elte.txtuml.export.uml2.activity.expression.CreationExporter
 import hu.elte.txtuml.export.uml2.activity.expression.MethodCallExporter
+import hu.elte.txtuml.utils.jdt.ElementTypeTeller
 import hu.elte.txtuml.utils.jdt.SharedUtils
 import org.eclipse.jdt.core.dom.Expression
 import org.eclipse.jdt.core.dom.ITypeBinding
@@ -10,6 +11,7 @@ import org.eclipse.jdt.core.dom.MethodInvocation
 import org.eclipse.jdt.core.dom.TypeLiteral
 import org.eclipse.uml2.uml.Action
 import org.eclipse.uml2.uml.Class
+import java.util.LinkedList
 
 class CreateActionExporter extends CreationExporter<MethodInvocation> {
 
@@ -42,6 +44,15 @@ class CreateActionExporter extends CreationExporter<MethodInvocation> {
 		]
 		if (ctor == null) {
 			throw new IllegalArgumentException('''The constructor of «createdType.name» with the arguments «args.toList» cannot be found.''')
+		}
+		if (ElementTypeTeller.isSignal(ctor.declaringClass)) {
+			val newArgs = new LinkedList(args.map[exportExpression].toList)
+			newArgs.add(0, create)
+			new MethodCallExporter(this).createCallFromActions(factory.createCallOperationAction,
+				ctor, null, newArgs).storeNode
+		} else {
+			new MethodCallExporter(this).createCall(factory.createCallOperationAction,
+				ctor, create, args).storeNode
 		}
 		new MethodCallExporter(this).createCall(factory.createCallOperationAction, ctor,
 			create, args).storeNode

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/ToStringExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/apicalls/ToStringExporter.xtend
@@ -1,0 +1,59 @@
+package hu.elte.txtuml.export.uml2.activity.apicalls
+
+import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.export.uml2.activity.ActionExporter
+import org.eclipse.jdt.core.dom.Expression
+import org.eclipse.jdt.core.dom.MethodInvocation
+import org.eclipse.uml2.uml.Action
+import org.eclipse.uml2.uml.CallOperationAction
+
+class ToStringExporter extends ActionExporter<MethodInvocation, CallOperationAction> {
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(MethodInvocation access) {
+		if(access.resolveMethodBinding.name == "toString" && access.arguments.isEmpty) factory.createCallOperationAction
+	}
+
+	override exportContents(MethodInvocation source) {
+		val action = exportExpression(source.expression)
+		createToString(result, action)
+	}
+	
+	def createToString(Action action) {
+		val res = createToString(factory.createCallOperationAction, action)
+		storeNode(res)
+		return res
+	}
+
+	def createToString(CallOperationAction ret, Action action) {
+		ret.name = '''«action.name».toString'''
+		ret.operation = getImportedOperation("ObjectOperations", "toString")
+		val arg = ret.createArgument("input", action.result.type)
+		action.result.objectFlow(arg)
+		ret.createResult("res", stringType)
+		return ret
+	}
+}
+
+class PrimitiveToStringExporter extends ActionExporter<MethodInvocation, CallOperationAction> {
+
+	private val VALUE_OF_CLASSES = #[Boolean, Byte, Short, Integer, Long, Float, Double].map[canonicalName]
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(MethodInvocation access) {
+		if (VALUE_OF_CLASSES.contains(access.resolveMethodBinding.declaringClass.qualifiedName) &&
+			access.resolveMethodBinding.name == "toString" && access.arguments.size == 1)
+			factory.createCallOperationAction
+	}
+
+	override exportContents(MethodInvocation source) {
+		val action = exportExpression(source.arguments.get(0) as Expression)
+		new ToStringExporter(this).createToString(result, action)
+	}
+}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
@@ -2,6 +2,7 @@ package hu.elte.txtuml.export.uml2.activity.expression
 
 import hu.elte.txtuml.export.uml2.BaseExporter
 import hu.elte.txtuml.export.uml2.activity.ActionExporter
+import hu.elte.txtuml.export.uml2.activity.apicalls.ToStringExporter
 import org.eclipse.jdt.core.dom.InfixExpression
 import org.eclipse.jdt.core.dom.InfixExpression.Operator
 import org.eclipse.uml2.uml.Action
@@ -54,10 +55,27 @@ class BinaryOperatorExporter extends ActionExporter<InfixExpression, CallOperati
 					default: objectNotEqualsOp
 				}
 		}
+		if (operator == concatOp) {
+			handleAutoConversion(source, operator)
+		}
 		val left = exportExpression(source.leftOperand)
 		val right = exportExpression(source.rightOperand)
 		finishOperator(result, source.operator.toString, operator, left, right)
 	}
+	
+	def handleAutoConversion(InfixExpression source, Operation operator) {
+		val left = autoToString(exportExpression(source.leftOperand))
+		val right = autoToString(exportExpression(source.rightOperand))
+		finishOperator(result, source.operator.toString, operator, left, right)
+	}
+	
+	def autoToString(Action action) {
+		if (action.result.type.name == "String") {
+			return action
+		} else {
+			new ToStringExporter(this).createToString(action)
+		}
+	}	
 
 	def minusOp() { getImportedOperation("IntegerOperations", "sub") }
 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
@@ -57,10 +57,11 @@ class BinaryOperatorExporter extends ActionExporter<InfixExpression, CallOperati
 		}
 		if (operator == concatOp) {
 			handleAutoConversion(source, operator)
+		} else {
+			val left = exportExpression(source.leftOperand)
+			val right = exportExpression(source.rightOperand)
+			finishOperator(result, source.operator.toString, operator, left, right)
 		}
-		val left = exportExpression(source.leftOperand)
-		val right = exportExpression(source.rightOperand)
-		finishOperator(result, source.operator.toString, operator, left, right)
 	}
 	
 	def handleAutoConversion(InfixExpression source, Operation operator) {

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/BinaryOperatorExporter.xtend
@@ -42,12 +42,6 @@ class BinaryOperatorExporter extends ActionExporter<InfixExpression, CallOperati
 				lessEqualsOp
 			case Operator.GREATER_EQUALS:
 				greaterEqualsOp
-			case Operator.EQUALS:
-				switch argType.name {
-					case "int": integerEqOp
-					case "bool": boolEqOp
-					default: objectEqOp
-				}
 			case Operator.NOT_EQUALS:
 				switch argType.name {
 					case "int": integerNotEqualsOp
@@ -101,12 +95,6 @@ class BinaryOperatorExporter extends ActionExporter<InfixExpression, CallOperati
 	def lessEqualsOp() { getImportedOperation("IntegerOperations", "leq") }
 
 	def greaterEqualsOp() { getImportedOperation("IntegerOperations", "geq") }
-
-	def integerEqOp() { getImportedOperation("IntegerOperations", "eq") }
-
-	def boolEqOp() { getImportedOperation("BooleanOperations", "eq") }
-
-	def objectEqOp() { getImportedOperation("ObjectOperations", "eq") }
 
 	def integerNotEqualsOp() { getImportedOperation("IntegerOperations", "neq") }
 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/CallExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/CallExporter.xtend
@@ -44,18 +44,24 @@ abstract class CallExporter<T> extends ActionExporter<T, CallOperationAction> {
 	}
 
 	def createCall(CallOperationAction call, IMethodBinding binding, Action base, Iterable<Expression> args) {
+		createCallFromActions(call, binding, base, args.map[exportExpression])
+	}
+	
+	def createCallFromActions(CallOperationAction call, IMethodBinding binding, Action base, Iterable<Action> args) {
 		call.operation = fetchElement(binding) as Operation
 
-		base?.result.objectFlow(call.createTarget("target", base.result.type))
+		if (base != null) {
+			base.result.objectFlow(call.createTarget("target", base.result.type))
+		}
 
 		val i = new AtomicInteger
-		args.forEach[call.createArgument("p" + i.andIncrement, resolveTypeBinding.fetchType)]
+		args.forEach[call.createArgument("p" + i.andIncrement, it.result.type)]
 
 		if (binding.returnType.name != "void") {
 			call.createResult("return", fetchType(binding.returnType))
 		}
 
-		val argVals = args.map[exportExpression].map[it.result]
+		val argVals = args.map[it.result]
 
 		for (argi : 0 ..< call.arguments.length) {
 			argVals.get(argi).objectFlow(call.arguments.get(argi))
@@ -65,7 +71,7 @@ abstract class CallExporter<T> extends ActionExporter<T, CallOperationAction> {
 	}
 
 	def buildName(IMethodBinding binding, CallOperationAction call, Action base) {
-		'''«base?.name.concat('.')»«binding.name»(«buildArgs(call)»)'''
+		'''«base?.name?.concat('.')»«binding.name»(«buildArgs(call)»)'''
 	}
 
 	def buildArgs(CallOperationAction call) {

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/CallExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/CallExporter.xtend
@@ -43,6 +43,13 @@ abstract class CallExporter<T> extends ActionExporter<T, CallOperationAction> {
 		}
 	}
 
+	def createCall(IMethodBinding binding, Action base, Iterable<Expression> args) {
+		val call = factory.createCallOperationAction
+		createCallFromActions(call, binding, base, args.map[exportExpression])
+		storeNode(call)
+		return call
+	}
+
 	def createCall(CallOperationAction call, IMethodBinding binding, Action base, Iterable<Expression> args) {
 		createCallFromActions(call, binding, base, args.map[exportExpression])
 	}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/ConstructorCallExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/ConstructorCallExporter.xtend
@@ -1,8 +1,10 @@
 package hu.elte.txtuml.export.uml2.activity.expression
 
 import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.utils.jdt.ElementTypeTeller
 import org.eclipse.jdt.core.dom.ClassInstanceCreation
 import org.eclipse.uml2.uml.Classifier
+import java.util.LinkedList
 
 class ConstructorCallExporter extends CreationExporter<ClassInstanceCreation> {
 
@@ -21,8 +23,15 @@ class ConstructorCallExporter extends CreationExporter<ClassInstanceCreation> {
 		val tempVar = result.createVariable("#temp", createdType)
 		tempVar.write(create)
 
-		new MethodCallExporter(this).createCall(factory.createCallOperationAction,
-			ctorBinding, tempVar.read, source.arguments).storeNode
+		if (ElementTypeTeller.isSignal(ctorBinding.declaringClass)) {
+			val newArgs = new LinkedList(source.arguments.map[exportExpression])
+			newArgs.add(0, tempVar.read)
+			new MethodCallExporter(this).createCallFromActions(factory.createCallOperationAction, ctorBinding, null,
+				newArgs).storeNode
+		} else {
+			new MethodCallExporter(this).createCall(factory.createCallOperationAction, ctorBinding, tempVar.read,
+				source.arguments).storeNode
+		}
 		tempVar.read
 
 		result.name = '''create «ctorBinding.declaringClass.name»'''

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/EqualityExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/EqualityExporter.xtend
@@ -1,0 +1,39 @@
+package hu.elte.txtuml.export.uml2.activity.expression
+
+import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.export.uml2.activity.ActionExporter
+import org.eclipse.jdt.core.dom.InfixExpression
+import org.eclipse.jdt.core.dom.InfixExpression.Operator
+import org.eclipse.uml2.uml.Action
+import org.eclipse.uml2.uml.TestIdentityAction
+
+class EqualityExporter extends ActionExporter<InfixExpression, TestIdentityAction> {
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(InfixExpression access) {
+		if(access.operator == Operator.EQUALS) factory.createTestIdentityAction
+	}
+
+	override exportContents(InfixExpression source) {
+		val left = exportExpression(source.leftOperand)
+		val right = exportExpression(source.rightOperand)
+		finishIdentityTest(result, left, right)
+	}
+
+	def exportOperator(Action left, Action right) {
+		val ret = factory.createTestIdentityAction
+		finishIdentityTest(ret, left, right)
+		storeNode(ret)
+		return ret
+	}
+
+	protected def finishIdentityTest(TestIdentityAction expr, Action left, Action right) {
+		expr.createResult("result", booleanType)
+		left.result.objectFlow(expr.createFirst("left", left.result.type))
+		right.result.objectFlow(expr.createSecond("right", right.result.type))
+		expr.name = '''«left.name»==«right.name»'''
+	}
+}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/PrefixOperatorExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/PrefixOperatorExporter.xtend
@@ -59,6 +59,10 @@ class PrefixOperatorExporter extends OperatorExporter<PrefixExpression> {
 
 	def logicalNot(Action expr) {
 		val act = factory.createCallOperationAction
+		finishLogicalNot(act, expr)
+	}
+	
+	def finishLogicalNot(CallOperationAction act, Action expr) {
 		val operator = getImportedOperation("BooleanOperations", "not")
 		act.name = '''!«expr.name»'''
 		finishOperation(act, expr, operator)

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/UnequalityExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/expression/UnequalityExporter.xtend
@@ -1,0 +1,23 @@
+package hu.elte.txtuml.export.uml2.activity.expression
+
+import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.export.uml2.activity.ActionExporter
+import org.eclipse.jdt.core.dom.InfixExpression
+import org.eclipse.jdt.core.dom.InfixExpression.Operator
+import org.eclipse.uml2.uml.CallOperationAction
+
+class UnequalityExporter extends ActionExporter<InfixExpression, CallOperationAction> {
+
+	new(BaseExporter<?, ?, ?> parent) {
+		super(parent)
+	}
+
+	override create(InfixExpression access) { if(access.operator == Operator.NOT_EQUALS) factory.createCallOperationAction }
+
+	override exportContents(InfixExpression source) {
+		val left = exportExpression(source.leftOperand)
+		val right = exportExpression(source.rightOperand)
+		val eqTest = new EqualityExporter(this).exportOperator(left, right)
+		new PrefixOperatorExporter(this).finishLogicalNot(result, eqTest)
+	}
+}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/statement/BlockExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/activity/statement/BlockExporter.xtend
@@ -1,8 +1,15 @@
 package hu.elte.txtuml.export.uml2.activity.statement
 
 import hu.elte.txtuml.export.uml2.BaseExporter
+import hu.elte.txtuml.export.uml2.activity.expression.MethodCallExporter
 import org.eclipse.jdt.core.dom.Block
+import org.eclipse.jdt.core.dom.ConstructorInvocation
+import org.eclipse.jdt.core.dom.MethodDeclaration
+import org.eclipse.jdt.core.dom.Statement
+import org.eclipse.jdt.core.dom.SuperConstructorInvocation
 import org.eclipse.uml2.uml.SequenceNode
+import hu.elte.txtuml.utils.jdt.ElementTypeTeller
+import hu.elte.txtuml.api.model.ModelClass
 
 class BlockExporter extends ControlExporter<Block, SequenceNode> {
 
@@ -13,6 +20,29 @@ class BlockExporter extends ControlExporter<Block, SequenceNode> {
 	override create(Block access) { factory.createSequenceNode }
 
 	override exportContents(Block source) {
+		val method = source.parent
+		// add implicit ctor call if necessary
+		switch method {
+			MethodDeclaration case method.constructor &&
+				!ElementTypeTeller.isSignal(method.resolveBinding.declaringClass) &&
+				(source.statements.isEmpty || !isCtorCall(source.statements.get(0) as Statement)): {
+				val superClass = method.resolveBinding.declaringClass.superclass
+				if (superClass.qualifiedName != ModelClass.canonicalName) {
+					val ctor = superClass.declaredMethods.filter[isConstructor].findFirst[parameterTypes.isEmpty]
+					result.executableNodes += new MethodCallExporter(this).createCall(ctor, null, #[])
+				}
+
+			}
+		}
 		result.executableNodes += source.statements.map[exportStatement]
 	}
+
+	def boolean isCtorCall(Statement stmt) {
+		switch stmt {
+			ConstructorInvocation: true
+			SuperConstructorInvocation: true
+			default: false
+		}
+	}
+
 }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/SignalFactoryExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/SignalFactoryExporter.xtend
@@ -6,6 +6,8 @@ import hu.elte.txtuml.utils.jdt.ElementTypeTeller
 import org.eclipse.jdt.core.dom.ITypeBinding
 import org.eclipse.jdt.core.dom.TypeDeclaration
 import org.eclipse.uml2.uml.Class
+import org.eclipse.uml2.uml.Operation
+import org.eclipse.uml2.uml.Type
 
 class SignalFactoryExporter extends Exporter<TypeDeclaration, ITypeBinding, Class> {
 
@@ -19,12 +21,24 @@ class SignalFactoryExporter extends Exporter<TypeDeclaration, ITypeBinding, Clas
 
 	override exportContents(TypeDeclaration source) {
 		result.name = '''#«source.name.identifier»_factory'''
-		source.methods.filter[isConstructor].forEach[exportOperation[result.ownedOperations += it]]
+		val signalType = fetchElement(source.resolveBinding, new SignalExporter(this))
+		source.methods.filter[isConstructor].map[exportOperation[result.ownedOperations += it]].forEach [
+			addSignalParameter(signalType)
+		]
 		source.methods.filter[isConstructor].forEach[exportActivity[result.ownedBehaviors += it]]
 		source.resolveBinding.declaredMethods.filter[isDefaultConstructor].forEach [
-			exportDefaultConstructor[result.ownedOperations += it]
+			val op = exportDefaultConstructor[result.ownedOperations += it]
+			addSignalParameter(op, signalType)
 			exportDefaultConstructorBody[result.ownedBehaviors += it]
 		]
+	}
+
+	def addSignalParameter(Operation op, Type signalType) {
+		op.isStatic = true
+		val parameter = factory.createParameter
+		parameter.type = signalType
+		parameter.name = "signal"
+		op.ownedParameters.add(0, parameter)
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.stdlib/src/hu/elte/txtuml/stdlib/stdlib.uml
+++ b/dev/plugins/hu.elte.txtuml.stdlib/src/hu/elte/txtuml/stdlib/stdlib.uml
@@ -379,6 +379,20 @@
         </ownedParameter>
       </ownedTemplateSignature>
     </ownedOperation>
+    <ownedOperation xmi:type="uml:Operation" xmi:id="_i2CYECC9EeaOft3ZDJwTtA" name="toString" isStatic="true">
+      <ownedParameter xmi:type="uml:Parameter" xmi:id="_i2CYESC9EeaOft3ZDJwTtA" name="inp" type="_4jBEcAY7Eeae1rX0uG0rnw">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_i2CYEiC9EeaOft3ZDJwTtA" value="1"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_i2CYEyC9EeaOft3ZDJwTtA" value="1"/>
+      </ownedParameter>
+      <ownedParameter xmi:type="uml:Parameter" xmi:id="_i2CYFCC9EeaOft3ZDJwTtA" name="res" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#String"/>
+      </ownedParameter>
+      <ownedTemplateSignature xmi:type="uml:TemplateSignature" xmi:id="_i2CYFSC9EeaOft3ZDJwTtA" parameter="_EIepICC-EeaOft3ZDJwTtA">
+        <ownedParameter xmi:type="uml:ClassifierTemplateParameter" xmi:id="_EIepICC-EeaOft3ZDJwTtA" parameteredElement="_SJAkoCC-EeaOft3ZDJwTtA">
+          <ownedParameteredElement xmi:type="uml:Class" xmi:id="_SJAkoCC-EeaOft3ZDJwTtA" name="E" templateParameter="_EIepICC-EeaOft3ZDJwTtA"/>
+        </ownedParameter>
+      </ownedTemplateSignature>
+    </ownedOperation>
   </packagedElement>
   <packagedElement xmi:type="uml:Class" xmi:id="_DJzhUNpoEeWuz-p1tuEm5Q" name="hu.elte.txtuml.api.model.Collection"/>
   <packagedElement xmi:type="uml:Class" xmi:id="_DubAAArpEeapa4Ow9IdZzQ" name="SignalOperations">

--- a/dev/plugins/hu.elte.txtuml.stdlib/src/hu/elte/txtuml/stdlib/stdlib.uml
+++ b/dev/plugins/hu.elte.txtuml.stdlib/src/hu/elte/txtuml/stdlib/stdlib.uml
@@ -393,6 +393,20 @@
         </ownedParameter>
       </ownedTemplateSignature>
     </ownedOperation>
+    <ownedOperation xmi:type="uml:Operation" xmi:id="_CM3bwCDkEeaOft3ZDJwTtA" name="count" isStatic="true">
+      <ownedParameter xmi:type="uml:Parameter" xmi:id="_CM3bwSDkEeaOft3ZDJwTtA" name="inp" type="_d-9psCDkEeaOft3ZDJwTtA">
+        <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_CM3bwiDkEeaOft3ZDJwTtA"/>
+        <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_CM3bwyDkEeaOft3ZDJwTtA" value="*"/>
+      </ownedParameter>
+      <ownedParameter xmi:type="uml:Parameter" xmi:id="_CM3bxCDkEeaOft3ZDJwTtA" name="res" direction="return">
+        <type xmi:type="uml:PrimitiveType" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#Integer"/>
+      </ownedParameter>
+      <ownedTemplateSignature xmi:type="uml:TemplateSignature" xmi:id="_b84dMCDkEeaOft3ZDJwTtA" parameter="_cqGIgCDkEeaOft3ZDJwTtA">
+        <ownedParameter xmi:type="uml:ClassifierTemplateParameter" xmi:id="_cqGIgCDkEeaOft3ZDJwTtA" parameteredElement="_d-9psCDkEeaOft3ZDJwTtA">
+          <ownedParameteredElement xmi:type="uml:Class" xmi:id="_d-9psCDkEeaOft3ZDJwTtA" name="E" templateParameter="_cqGIgCDkEeaOft3ZDJwTtA"/>
+        </ownedParameter>
+      </ownedTemplateSignature>
+    </ownedOperation>
   </packagedElement>
   <packagedElement xmi:type="uml:Class" xmi:id="_DJzhUNpoEeWuz-p1tuEm5Q" name="hu.elte.txtuml.api.model.Collection"/>
   <packagedElement xmi:type="uml:Class" xmi:id="_DubAAArpEeapa4Ow9IdZzQ" name="SignalOperations">

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
@@ -25,6 +25,7 @@ import org.eclipse.uml2.uml.SequenceNode;
 import org.eclipse.uml2.uml.SignalEvent;
 import org.eclipse.uml2.uml.StartObjectBehaviorAction;
 import org.eclipse.uml2.uml.State;
+import org.eclipse.uml2.uml.TestIdentityAction;
 import org.eclipse.uml2.uml.Transition;
 import org.eclipse.uml2.uml.ValueSpecificationAction;
 import org.junit.BeforeClass;
@@ -240,6 +241,29 @@ public class TestActionCode extends UMLExportTestBase {
 		SequenceNode stmt = node(body, 0, "3;", SequenceNode.class);
 		SequenceNode valueOfNode = node(stmt, 0, "3", SequenceNode.class);
 		node(valueOfNode, 0, "3", ValueSpecificationAction.class);
+	}	
+	
+	@Test
+	public void testEquality() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.equalities");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testEquality");
+		node(body, 0, "\"Fdf\"", ValueSpecificationAction.class);
+		node(body, 1, "\"Str\"", ValueSpecificationAction.class);
+		node(body, 2, "\"Fdf\"==\"Str\"", TestIdentityAction.class);
+		node(body, 3, "b=\"Fdf\"==\"Str\"", AddVariableValueAction.class);
+	}	
+	
+	@Test
+	public void testInequality() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.equalities");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testInequality");
+		node(body, 0, "\"Fdf\"", ValueSpecificationAction.class);
+		node(body, 1, "\"Str\"", ValueSpecificationAction.class);
+		node(body, 2, "\"Fdf\"==\"Str\"", TestIdentityAction.class);
+		node(body, 3, "!\"Fdf\"==\"Str\"", CallOperationAction.class);
+		node(body, 4, "b=!\"Fdf\"==\"Str\"", AddVariableValueAction.class);
 	}	
 
 }

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import org.eclipse.uml2.uml.Activity;
+import org.eclipse.uml2.uml.ActivityParameterNode;
 import org.eclipse.uml2.uml.AddStructuralFeatureValueAction;
 import org.eclipse.uml2.uml.AddVariableValueAction;
 import org.eclipse.uml2.uml.CallOperationAction;
@@ -182,7 +183,9 @@ public class TestActionCode extends UMLExportTestBase {
 		SequenceNode effectBody = getActivityBody((Activity) tr1.getEffect());
 		node(effectBody, 0, "Action.log(\"Init -> S1\");", SequenceNode.class);
 		Transition tr2 = transition(reg, s1, s1, sig);
-		SequenceNode guardBody = getActivityBody(getGuardActivity(tr2));
+		Activity guardActivity = getGuardActivity(tr2);
+		node(guardActivity, 2, "return", ActivityParameterNode.class);
+		SequenceNode guardBody = getActivityBody(guardActivity);
 		node(guardBody, 0, "return false", SequenceNode.class);
 	}
 

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
@@ -265,5 +265,12 @@ public class TestActionCode extends UMLExportTestBase {
 		node(body, 3, "!\"Fdf\"==\"Str\"", CallOperationAction.class);
 		node(body, 4, "b=!\"Fdf\"==\"Str\"", AddVariableValueAction.class);
 	}	
+	
+	@Test
+	public void testImplicitCtorInvoke() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.ctors");
+		SequenceNode body = loadActionCode(model, "ClassExtending", "ClassExtending");
+		node(body, 0, "ClassWithCtors()", CallOperationAction.class);
+	}
 
 }

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestActionCode.java
@@ -199,5 +199,47 @@ public class TestActionCode extends UMLExportTestBase {
 		node(logStmt, 0, "inst", ReadVariableAction.class);
 		node(logStmt, 1, "start inst", StartObjectBehaviorAction.class);
 	}	
+	
+	@Test
+	public void testToString() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.toString");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testToString");
+		SequenceNode toStringStmt = node(body, 0, "sut.toString;", SequenceNode.class);
+		node(toStringStmt, 0, "sut", ReadVariableAction.class);
+		node(toStringStmt, 1, "sut.toString", CallOperationAction.class);
+	}	
+	
+	@Test
+	public void testPrimitiveToString() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.toString");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testPrimitiveToString");
+		SequenceNode toStringStmt = node(body, 0, "3.toString;", SequenceNode.class);
+		node(toStringStmt, 0, "3", ValueSpecificationAction.class);
+		node(toStringStmt, 1, "3.toString", CallOperationAction.class);
+	}
+	
+	@Test
+	public void testAutoToString() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.toString");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testAuto");
+		node(body, 0, "\"a\"", ValueSpecificationAction.class);
+		node(body, 1, "3", ValueSpecificationAction.class);
+		node(body, 2, "3.toString", CallOperationAction.class);
+		node(body, 3, "\"a\"+3.toString", CallOperationAction.class);
+		node(body, 4, "a=\"a\"+3.toString", AddVariableValueAction.class);
+	}	
+	
+	@Test
+	public void testValueOf() throws Exception {
+		Model model = model("hu.elte.txtuml.export.uml2.tests.models.valueOf");
+
+		SequenceNode body = loadActionCode(model, "TestClass", "testValueOf");
+		SequenceNode stmt = node(body, 0, "3;", SequenceNode.class);
+		SequenceNode valueOfNode = node(stmt, 0, "3", SequenceNode.class);
+		node(valueOfNode, 0, "3", ValueSpecificationAction.class);
+	}	
 
 }

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestStructure.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestStructure.java
@@ -248,17 +248,18 @@ public class TestStructure extends UMLExportTestBase {
 		assertEquals(sig, sigEvent.getSignal());
 		Class sigFactory = cls(model, "#Sig_factory");
 		Operation sigCtor = operation(sigFactory, "Sig");
+		assertEquals(4, sigCtor.getOwnedParameters().size());
 
 		SequenceNode body = loadActionCode(model, "A", "test");
 		SequenceNode createNode = node(body, 0, "create Sig", SequenceNode.class);
 		CreateObjectAction initiateNode = node(createNode, 0, "instantiate Sig", CreateObjectAction.class);
 		assertEquals(sig, initiateNode.getClassifier());
 		node(createNode, 1, "#temp=instantiate Sig", AddVariableValueAction.class);
-		node(createNode, 2, "#temp", ReadVariableAction.class);
-		node(createNode, 3, "1", ValueSpecificationAction.class);
-		node(createNode, 4, "true", ValueSpecificationAction.class);
-		node(createNode, 5, "\"test\"", ValueSpecificationAction.class);
-		CallOperationAction ctorCall = node(createNode, 6, "#temp.Sig(Integer p0, Boolean p1, String p2)", CallOperationAction.class);
+		node(createNode, 2, "1", ValueSpecificationAction.class);
+		node(createNode, 3, "true", ValueSpecificationAction.class);
+		node(createNode, 4, "\"test\"", ValueSpecificationAction.class);
+		node(createNode, 5, "#temp", ReadVariableAction.class);
+		CallOperationAction ctorCall = node(createNode, 6, "#temp.Sig(Sig p0, Integer p1, Boolean p2, String p3)", CallOperationAction.class);
 		assertEquals(sigCtor, ctorCall.getOperation());
 		node(createNode, 7, "#temp", ReadVariableAction.class);
 	}

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestStructure.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/TestStructure.java
@@ -259,7 +259,7 @@ public class TestStructure extends UMLExportTestBase {
 		node(createNode, 3, "true", ValueSpecificationAction.class);
 		node(createNode, 4, "\"test\"", ValueSpecificationAction.class);
 		node(createNode, 5, "#temp", ReadVariableAction.class);
-		CallOperationAction ctorCall = node(createNode, 6, "#temp.Sig(Sig p0, Integer p1, Boolean p2, String p3)", CallOperationAction.class);
+		CallOperationAction ctorCall = node(createNode, 6, "Sig(Sig p0, Integer p1, Boolean p2, String p3)", CallOperationAction.class);
 		assertEquals(sigCtor, ctorCall.getOperation());
 		node(createNode, 7, "#temp", ReadVariableAction.class);
 	}

--- a/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/UMLExportTestBase.java
+++ b/dev/tests/hu.elte.txtuml.export.uml2.tests/src/hu/elte/txtuml/export/uml2/UMLExportTestBase.java
@@ -129,6 +129,15 @@ public class UMLExportTestBase {
 		return (T) node;
 	}
 
+	@SuppressWarnings("unchecked")
+	protected <T> T node(Activity parent, int index, String name, java.lang.Class<T> type) {
+		ActivityNode node = parent.getNodes().get(index);
+		assertEquals(name, node.getName());
+		assertNotNull(node);
+		assertTrue("Node is not a " + type.getName(), type.isInstance(node));
+		return (T) node;
+	}
+	
 	protected void checkDefaultCtor(SequenceNode body) {
 		SequenceNode createNode = (SequenceNode) body.getNode("create DefaultConstructible;");
 		SequenceNode createExprNode = (SequenceNode) createNode.getNode("create DefaultConstructible");

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/ctors/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/ctors/TestClass.java
@@ -41,5 +41,11 @@ class ClassWithCtors extends ModelClass {
 	}
 }
 
+class ClassExtending extends ClassWithCtors {
+	
+	public ClassExtending() {
+	}
+}
+
 class DefaultConstructible extends ModelClass {
 }

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/equalities/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/equalities/TestClass.java
@@ -1,0 +1,15 @@
+package hu.elte.txtuml.export.uml2.tests.models.equalities;
+
+import hu.elte.txtuml.api.model.ModelClass;
+
+public class TestClass extends ModelClass {
+	
+	public void testEquality() {
+		boolean b = "Fdf" == "Str";
+	}
+	
+	public void testInequality() {
+		boolean b = "Fdf" != "Str";
+	}
+	
+}

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/equalities/package-info.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/equalities/package-info.java
@@ -1,0 +1,4 @@
+@Model
+package hu.elte.txtuml.export.uml2.tests.models.equalities;
+
+import hu.elte.txtuml.api.model.Model;

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
@@ -4,13 +4,13 @@ import hu.elte.txtuml.api.model.ModelClass;
 
 public class TestClass extends ModelClass {
 	
-//	public void testToString(TestClass sut) {
-//		String a = sut.toString();
-//	}
-//	
-//	public void testPrimitiveToString() {
-//		String a = Integer.toString(3);
-//	}
+	public void testToString(TestClass sut) {
+		String a = sut.toString();
+	}
+	
+	public void testPrimitiveToString() {
+		String a = Integer.toString(3);
+	}
 	
 	public void testAuto() {
 		String a = "a" + 3;

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
@@ -1,0 +1,18 @@
+package hu.elte.txtuml.export.uml2.tests.models.toString;
+
+import hu.elte.txtuml.api.model.ModelClass;
+
+public class TestClass extends ModelClass {
+	
+//	public void testToString(TestClass sut) {
+//		String a = sut.toString();
+//	}
+//	
+//	public void testPrimitiveToString() {
+//		String a = Integer.toString(3);
+//	}
+	
+	public void testAuto() {
+		String a = "a" + 3;
+	}
+}

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/TestClass.java
@@ -5,11 +5,11 @@ import hu.elte.txtuml.api.model.ModelClass;
 public class TestClass extends ModelClass {
 	
 	public void testToString(TestClass sut) {
-		String a = sut.toString();
+		sut.toString();
 	}
 	
 	public void testPrimitiveToString() {
-		String a = Integer.toString(3);
+		Integer.toString(3);
 	}
 	
 	public void testAuto() {

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/package-info.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/toString/package-info.java
@@ -1,0 +1,4 @@
+@Model
+package hu.elte.txtuml.export.uml2.tests.models.toString;
+
+import hu.elte.txtuml.api.model.Model;

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/TestClass.java
@@ -4,7 +4,7 @@ import hu.elte.txtuml.api.model.ModelClass;
 
 public class TestClass extends ModelClass {
 	
-	public void testToString() {
-		Integer a = Integer.valueOf(3);
+	public void testValueOf() {
+		Integer.valueOf(3);
 	}
 }

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/TestClass.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/TestClass.java
@@ -1,0 +1,10 @@
+package hu.elte.txtuml.export.uml2.tests.models.valueOf;
+
+import hu.elte.txtuml.api.model.ModelClass;
+
+public class TestClass extends ModelClass {
+	
+	public void testToString() {
+		Integer a = Integer.valueOf(3);
+	}
+}

--- a/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/package-info.java
+++ b/examples/tests/hu.elte.txtuml.export.uml2.tests.models/src/hu/elte/txtuml/export/uml2/tests/models/valueOf/package-info.java
@@ -1,0 +1,4 @@
+@Model
+package hu.elte.txtuml.export.uml2.tests.models.valueOf;
+
+import hu.elte.txtuml.api.model.Model;


### PR DESCRIPTION
Resolves action-code related issues:
 - Resolves #353
 - Resolves #357 
 - Resolves #356 
 - Resolves #362 
 - Resolves #47
 - Resolves #352

The goal is that C++ tests should be able to run in pedantic mode, that requires the Xtext-generated java code to be exportable.

Additionally, the `count` operation had been enabled to be able to export the `producer_consumer` model.