### PR TITLE
Fixes and improvements in validation

### DIFF
--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/META-INF/MANIFEST.MF
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: hu.elte.txtuml.xtxtuml;bundle-version="0.5.0";visibility:=reexpo
  org.eclipse.compare,
  hu.elte.txtuml.api.model;bundle-version="0.5.0",
  org.eclipse.jdt.core;bundle-version="3.11.1",
- hu.elte.txtuml.utils;bundle-version="0.5.0"
+ hu.elte.txtuml.utils;bundle-version="0.5.0",
+ hu.elte.txtuml.validation;bundle-version="0.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: hu.elte.txtuml.xtxtuml.ui.quickfix,

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/META-INF/MANIFEST.MF
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: hu.elte.txtuml.xtxtuml;bundle-version="0.5.0";visibility:=reexpo
  org.eclipse.xtext.ui.codetemplates.ui,
  org.eclipse.compare,
  hu.elte.txtuml.api.model;bundle-version="0.5.0",
- org.eclipse.jdt.core;bundle-version="3.11.1"
+ org.eclipse.jdt.core;bundle-version="3.11.1",
+ hu.elte.txtuml.utils;bundle-version="0.5.0"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: hu.elte.txtuml.xtxtuml.ui.quickfix,

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/plugin.xml
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/plugin.xml
@@ -689,4 +689,11 @@
      </shortcut>
   </extension>
 
+  <extension
+        point="org.eclipse.xtext.ui.shared.overridingGuiceModule">
+     <module
+           class="hu.elte.txtuml.xtxtuml.ui.BuilderCustomizationModule">
+     </module>
+  </extension>
+
 </plugin>

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/BuilderCustomizationModule.java
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/BuilderCustomizationModule.java
@@ -1,13 +1,14 @@
-package hu.elte.txtuml.xtxtuml;
+package hu.elte.txtuml.xtxtuml.ui;
 
 import org.eclipse.xtext.builder.smap.DerivedResourceMarkerCopier;
 import org.eclipse.xtext.service.AbstractGenericModule;
 
-import hu.elte.txtuml.xtxtuml.validation.XtxtUMLDerivedResourceMarkerCopier;
+import hu.elte.txtuml.xtxtuml.ui.validation.XtxtUMLDerivedResourceMarkerCopier;
 
 public class BuilderCustomizationModule extends AbstractGenericModule {
 
 	public Class<? extends DerivedResourceMarkerCopier> bindDerivedResourceMarkerCopier() {
 		return XtxtUMLDerivedResourceMarkerCopier.class;
 	}
+
 }

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/XtxtUMLUiModule.java
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/XtxtUMLUiModule.java
@@ -1,12 +1,14 @@
 package hu.elte.txtuml.xtxtuml.ui;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.xbase.ui.hover.XbaseDeclarativeHoverSignatureProvider;
 import org.eclipse.xtext.xbase.ui.hover.XbaseHoverDocumentationProvider;
 import org.eclipse.xtext.xbase.ui.quickfix.TypeNameGuesser;
+import org.eclipse.xtext.xbase.ui.validation.XbaseUIValidator;
 
 import hu.elte.txtuml.xtxtuml.ui.contentassist.XtxtUMLReferenceProposalCreator;
 import hu.elte.txtuml.xtxtuml.ui.highlighting.XtxtUMLHighlightingCalculator;
@@ -14,6 +16,7 @@ import hu.elte.txtuml.xtxtuml.ui.highlighting.XtxtUMLHighlightingConfiguration;
 import hu.elte.txtuml.xtxtuml.ui.hover.XtxtUMLDeclarativeHoverSignatureProvider;
 import hu.elte.txtuml.xtxtuml.ui.hover.XtxtUMLHoverDocumentationProvider;
 import hu.elte.txtuml.xtxtuml.ui.quickfix.XtxtUMLTypeNameGuesser;
+import hu.elte.txtuml.xtxtuml.ui.validation.XtxtUMLUIValidator;
 
 public class XtxtUMLUiModule extends hu.elte.txtuml.xtxtuml.ui.AbstractXtxtUMLUiModule {
 
@@ -46,6 +49,12 @@ public class XtxtUMLUiModule extends hu.elte.txtuml.xtxtuml.ui.AbstractXtxtUMLUi
 	@Override
 	public Class<? extends IHighlightingConfiguration> bindIHighlightingConfiguration() {
 		return XtxtUMLHighlightingConfiguration.class;
+	}
+
+	@Override
+	@SingletonBinding(eager = true)
+	public Class<? extends XbaseUIValidator> bindXbaseUIValidator() {
+		return XtxtUMLUIValidator.class;
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/XtxtUMLUiModule.java
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/XtxtUMLUiModule.java
@@ -1,6 +1,7 @@
 package hu.elte.txtuml.xtxtuml.ui;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.xtext.builder.IXtextBuilderParticipant;
 import org.eclipse.xtext.service.SingletonBinding;
 import org.eclipse.xtext.ui.editor.contentassist.AbstractJavaBasedContentProposalProvider;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
@@ -16,6 +17,7 @@ import hu.elte.txtuml.xtxtuml.ui.highlighting.XtxtUMLHighlightingConfiguration;
 import hu.elte.txtuml.xtxtuml.ui.hover.XtxtUMLDeclarativeHoverSignatureProvider;
 import hu.elte.txtuml.xtxtuml.ui.hover.XtxtUMLHoverDocumentationProvider;
 import hu.elte.txtuml.xtxtuml.ui.quickfix.XtxtUMLTypeNameGuesser;
+import hu.elte.txtuml.xtxtuml.ui.validation.XtxtUMLBuilderParticipant;
 import hu.elte.txtuml.xtxtuml.ui.validation.XtxtUMLUIValidator;
 
 public class XtxtUMLUiModule extends hu.elte.txtuml.xtxtuml.ui.AbstractXtxtUMLUiModule {
@@ -55,6 +57,11 @@ public class XtxtUMLUiModule extends hu.elte.txtuml.xtxtuml.ui.AbstractXtxtUMLUi
 	@SingletonBinding(eager = true)
 	public Class<? extends XbaseUIValidator> bindXbaseUIValidator() {
 		return XtxtUMLUIValidator.class;
+	}
+
+	@Override
+	public Class<? extends IXtextBuilderParticipant> bindIXtextBuilderParticipant() {
+		return XtxtUMLBuilderParticipant.class;
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLBuilderParticipant.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLBuilderParticipant.xtend
@@ -1,0 +1,94 @@
+package hu.elte.txtuml.xtxtuml.ui.validation;
+
+import com.google.inject.Inject
+import hu.elte.txtuml.utils.Logger
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUFile
+import hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage
+import org.eclipse.core.internal.resources.ResourceException
+import org.eclipse.core.resources.IMarker
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.IResourceStatus
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.builder.BuilderParticipant
+import org.eclipse.xtext.resource.ILocationInFileProvider
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.ui.MarkerTypes
+import org.eclipse.xtext.ui.resource.IResourceSetProvider
+
+class XtxtUMLBuilderParticipant extends BuilderParticipant {
+
+	@Inject IResourceSetProvider resourceSetProvider;
+	@Inject extension ILocationInFileProvider;
+
+	/**
+	 * Overrides the default implementation to provide meaningful error messages in case
+	 * of a {@link ResourceException} occurs due to case insensitive class file duplication.
+	 */
+	override protected addMarkerAndLogError(URI uri, Throwable e) {
+		for (storage : storage2UriMapper.getStorages(uri)) {
+			var IResource resource = null;
+			if (storage.first instanceof IResource) {
+				resource = storage.first as IResource;
+			} else {
+				resource = storage.second;
+			}
+			if (resource != null) {
+				try {
+					val marker = resource.createMarker(MarkerTypes.NORMAL_VALIDATION);
+
+					// start of modified code
+
+					var startChar = 0;
+					var endChar = 1;
+					var message = e.message + " - See error log for details";
+
+					if (e instanceof ResourceException &&
+						(e as ResourceException).status.code == IResourceStatus.CASE_VARIANT_EXISTS) {
+						val xResource = resourceSetProvider.get(resource.project).getResource(uri, true);
+						if (xResource instanceof XtextResource) {
+							val startPos = e.message.lastIndexOf("/") + 1;
+							val endPos = e.message.indexOf(".java");
+							val conflictingName = e.message.substring(startPos, endPos);
+								// cross-file conflicts occur only on class level, there's no need to handle '$'-s
+
+							val rootElement = xResource.contents.findFirst[it instanceof TUFile] as TUFile;
+							val duplicateElement = rootElement?.elements?.findFirst [
+								eGet(XtxtUMLPackage.Literals.TU_MODEL_ELEMENT__NAME, true)?.toString?.toLowerCase ==
+									conflictingName.toLowerCase;
+							]
+
+							if (duplicateElement != null) {
+								val nameRegion = duplicateElement.significantTextRegion;
+								startChar = nameRegion.offset;
+								endChar = startChar + nameRegion.length;
+
+								val name = duplicateElement.eGet(XtxtUMLPackage.Literals.TU_MODEL_ELEMENT__NAME, true)?.toString;
+								message = '''Model element «name» is a duplicate of model element «conflictingName» – uniqueness validation in this case is case insensitive''';
+							}
+						}
+					}
+
+					marker.setAttribute(IMarker.CHAR_START, startChar);
+					marker.setAttribute(IMarker.CHAR_END, endChar);
+					marker.setAttribute(IMarker.MESSAGE, message);
+					marker.setAttribute(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+
+					// end of modified code
+				} catch (CoreException ce) {
+					Logger.sys.error("Could not create marker", ce);
+				}
+			}
+		}
+		var Throwable cause = e;
+		if (cause instanceof CoreException) {
+			cause = cause.cause;
+		}
+		if (uri == null) {
+			Logger.sys.error("Error during compilation.", e);
+		} else {
+			Logger.sys.error("Error during compilation of '" + uri + "'.", e);
+		}
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLDerivedResourceMarkerCopier.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLDerivedResourceMarkerCopier.xtend
@@ -1,10 +1,11 @@
-package hu.elte.txtuml.xtxtuml.validation
+package hu.elte.txtuml.xtxtuml.ui.validation;
 
 import com.google.common.collect.ImmutableSet
 import com.google.inject.Inject
+import hu.elte.txtuml.utils.Logger
 import hu.elte.txtuml.validation.JtxtUMLCompilationParticipant
+import hu.elte.txtuml.xtxtuml.validation.XtxtUMLIssueCodes
 import java.util.Set
-import org.apache.log4j.Logger
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IMarker
 import org.eclipse.core.resources.IResource
@@ -26,10 +27,7 @@ import org.eclipse.xtext.validation.IssueSeveritiesProvider
 
 class XtxtUMLDerivedResourceMarkerCopier extends DerivedResourceMarkerCopier {
 
-	static val LOG = Logger.getLogger(XtxtUMLDerivedResourceMarkerCopier)
-
 	public static val PROPAGATED_FROM_FILE = "fromFile"
-
 	val fileExtensions = ImmutableSet.of("txtuml", "xtxtuml")
 
 	@Inject
@@ -98,7 +96,7 @@ class XtxtUMLDerivedResourceMarkerCopier extends DerivedResourceMarkerCopier {
 						sourceMarkerType = determinateMarkerTypeByURI(associatedLocation.getSrcRelativeResourceURI());
 					}
 					if (!srcFile.equals(findIFile(associatedLocation, srcFile.getWorkspace()))) {
-						LOG.error("File in associated location is not the same as main source file.");
+						Logger.sys.error("File in associated location is not the same as main source file.");
 					}
 					val xtendMarker = srcFile.createMarker(sourceMarkerType);
 					xtendMarker.setAttribute(IMarker.MESSAGE, message);
@@ -158,7 +156,7 @@ class XtxtUMLDerivedResourceMarkerCopier extends DerivedResourceMarkerCopier {
 	private def findIFile(ILocationInResource locationInResource, IWorkspace workspace) {
 		val storage = locationInResource.getStorage()
 		if (storage == null) {
-			LOG.warn("Failed to find Storage. Please make sure there are no outdated generated files. URI: " +
+			Logger.sys.warn("Failed to find Storage. Please make sure there are no outdated generated files. URI: " +
 				locationInResource.getAbsoluteResourceURI())
 			return null;
 		}

--- a/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLUIValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml.ui/src/hu/elte/txtuml/xtxtuml/ui/validation/XtxtUMLUIValidator.xtend
@@ -1,0 +1,85 @@
+package hu.elte.txtuml.xtxtuml.ui.validation
+
+import com.google.inject.Inject
+import hu.elte.txtuml.utils.Logger
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUFile
+import hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage
+import java.util.List
+import org.eclipse.core.resources.IFile
+import org.eclipse.emf.ecore.EPackage
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.core.JavaModelException
+import org.eclipse.xtext.ui.resource.IStorage2UriMapper
+import org.eclipse.xtext.validation.Check
+import org.eclipse.xtext.xbase.ui.validation.XbaseUIValidator
+
+import static hu.elte.txtuml.xtxtuml.validation.XtxtUMLIssueCodes.*
+import static hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage.Literals.*
+
+class XtxtUMLUIValidator extends XbaseUIValidator {
+
+	@Inject extension IStorage2UriMapper;
+
+	/**
+	 * Overrides the default implementation to let this class validate XtxtUML elements too.
+	 */
+	override protected List<EPackage> getEPackages() {
+		(super.EPackages + #[XtxtUMLPackage.eINSTANCE]).toList
+	}
+
+	@Check
+	def checkExpectedPackageName(TUFile file) {
+		val declaredPackage = file.name;
+		val expectedPackage = file.expectedPackageName;
+		if (expectedPackage != null &&
+			!(expectedPackage.isEmpty && declaredPackage == null || expectedPackage == declaredPackage)) {
+			error(
+				"The declared package '" + packageNameAsString(declaredPackage) +
+					"' does not match the expected package '" + packageNameAsString(expectedPackage) + "'", file,
+				TU_FILE__NAME, WRONG_PACKAGE);
+		}
+	}
+
+	def private getExpectedPackageName(TUFile file) {
+		val fileURI = file.eResource.URI;
+
+		for (storage : fileURI.storages) {
+			if (storage.first instanceof IFile) {
+				val javaProject = JavaCore.create(storage.second);
+				if (javaProject != null && javaProject.exists && javaProject.open) {
+					try {
+
+						for (root : javaProject.packageFragmentRoots) {
+							if (!root.archive && !root.external) {
+								val resource = root.resource;
+								if (resource != null) {
+									val fileWorkspacePath = storage.first.fullPath;
+									val sourceFolderPath = resource.fullPath;
+
+									if (sourceFolderPath.isPrefixOf(fileWorkspacePath)) {
+										val claspathRelativePath = fileWorkspacePath.makeRelativeTo(sourceFolderPath);
+										return claspathRelativePath.removeLastSegments(1).toString.replace("/", ".");
+									}
+								}
+							}
+						}
+
+					} catch (JavaModelException e) {
+						Logger.sys.error("Error while resolving expected path for TUFile", e);
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	def private packageNameAsString(String packageName) {
+		if (packageName == null || packageName.empty) {
+			"(default package)"
+		} else {
+			packageName
+		}
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/plugin.xml
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/plugin.xml
@@ -10,11 +10,5 @@
        genModel = "model/generated/XtxtUML.genmodel" /> 
 	
   </extension>
-  <extension
-        point="org.eclipse.xtext.ui.shared.overridingGuiceModule">
-     <module
-           class="hu.elte.txtuml.xtxtuml.BuilderCustomizationModule">
-     </module>
-  </extension>
 
 </plugin>

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/XtxtUML.xtext
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/XtxtUML.xtext
@@ -9,7 +9,7 @@ import "http://www.eclipse.org/xtext/xbase/Xtype" as xtype
 
 TUFile :
 	TUModelDeclaration |
-	('package' name=QualifiedName ';'?
+	(('package' name=QualifiedName ';'?)?
 	importSection=XImportSection?
 	elements+=TUModelElement*)
 ;

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/common/XtxtUMLUtils.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/common/XtxtUMLUtils.xtend
@@ -1,12 +1,15 @@
 package hu.elte.txtuml.xtxtuml.common
 
 import com.google.inject.Inject
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUClass
+import org.eclipse.xtext.naming.IQualifiedNameProvider
 import org.eclipse.xtext.resource.IEObjectDescription
 import org.eclipse.xtext.resource.IResourceDescriptions
 
 public class XtxtUMLUtils {
 
 	@Inject IResourceDescriptions index;
+	@Inject extension IQualifiedNameProvider;
 
 	def getEContainerDescription(IEObjectDescription objectDescription) {
 		val objectUriFragment = objectDescription.EObjectURI.fragment;
@@ -16,6 +19,43 @@ public class XtxtUMLUtils {
 		return resourceDescription.exportedObjects.findFirst [
 			EObjectURI.fragment == containerUriFragment
 		];
+	}
+
+	/**
+	 * Travels the class hierarchy of <code>clazz</code> upwards (inclusive), until a class
+	 * which satisfies <code>predicate</code> is found, or the hierarchy ends, or a cycle in
+	 * the hierarchy is found.
+	 * 
+	 * @return
+	 * <ul>
+	 * 	<li><code>true</code> if an appropriate class has been found,</li>
+	 * 	<li><code>false</code> if no appropriate class has been found,</li>
+	 * 	<li><code>null</code> if a cycle has been found during the traversal.</li>
+	 * </ul> 
+	 */
+	def travelClassHierarchy(TUClass clazz, (TUClass)=>Boolean predicate) {
+		if (predicate.apply(clazz)) {
+			return true;
+		}
+
+		val visitedClassNames = newHashSet;
+		visitedClassNames.add(clazz.fullyQualifiedName);
+
+		var currentClass = clazz.superClass;
+		while (currentClass != null) {
+			if (visitedClassNames.contains(currentClass.fullyQualifiedName)) {
+				return null;
+			}
+
+			if (predicate.apply(currentClass)) {
+				return true;
+			}
+
+			visitedClassNames.add(currentClass.fullyQualifiedName);
+			currentClass = currentClass.superClass;
+		}
+
+		return false;
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/typesystem/XtxtUMLReentrantTypeResolver.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/typesystem/XtxtUMLReentrantTypeResolver.xtend
@@ -1,10 +1,11 @@
-package hu.elte.txtuml.xtxtuml.typesystem
+package hu.elte.txtuml.xtxtuml.typesystem;
 
 import com.google.common.collect.ImmutableMap
 import hu.elte.txtuml.api.model.ModelClass
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUClass
 import org.eclipse.xtext.common.types.JvmDeclaredType
 import org.eclipse.xtext.common.types.JvmTypeReference
+import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.xbase.scoping.batch.IFeatureNames
 import org.eclipse.xtext.xbase.scoping.batch.IFeatureScopeSession
 import org.eclipse.xtext.xbase.typesystem.internal.LogicalContainerAwareReentrantTypeResolver
@@ -59,6 +60,10 @@ class XtxtUMLReentrantTypeResolver extends LogicalContainerAwareReentrantTypeRes
 			childSession = childSession.addNestedTypesToScope(thisMaybeModelClassType);
 
 		return childSession;
+	}
+
+	override protected createResolvedTypes(CancelIndicator monitor) {
+		return new XtxtUMLRootResolvedTypes(this, monitor);
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/typesystem/XtxtUMLRootResolvedTypes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/typesystem/XtxtUMLRootResolvedTypes.xtend
@@ -1,0 +1,62 @@
+package hu.elte.txtuml.xtxtuml.typesystem;
+
+import org.eclipse.xtext.diagnostics.AbstractDiagnostic
+import org.eclipse.xtext.diagnostics.Severity
+import org.eclipse.xtext.util.CancelIndicator
+import org.eclipse.xtext.validation.EObjectDiagnosticImpl
+import org.eclipse.xtext.xbase.XExpression
+import org.eclipse.xtext.xbase.XbasePackage
+import org.eclipse.xtext.xbase.typesystem.internal.DefaultReentrantTypeResolver
+import org.eclipse.xtext.xbase.typesystem.internal.RootResolvedTypes
+import org.eclipse.xtext.xbase.typesystem.references.LightweightTypeReference
+import org.eclipse.xtext.xbase.validation.IssueCodes
+
+class XtxtUMLRootResolvedTypes extends RootResolvedTypes {
+
+	protected new(DefaultReentrantTypeResolver resolver, CancelIndicator monitor) {
+		super(resolver, monitor)
+	}
+
+	/**
+	 * Overrides the super behavior to use fully qualified names in type mismatch error messages
+	 * in case of the simple type names are equal. Copied from the super implementation, the
+	 * customized part is marked with comments.
+	 */
+	override protected AbstractDiagnostic createTypeDiagnostic(XExpression expression,
+		LightweightTypeReference actualType, LightweightTypeReference expectedType) {
+		if (!expectedType.isAny) {
+			val actualName = actualType.simpleName;
+			val expectedName = expectedType.simpleName;
+			if (actualName == expectedName) {
+				if (expectedType.isAssignableFrom(actualType)) {
+					return null;
+				}
+			}
+
+			if (expression.eContainingFeature ==
+				XbasePackage.Literals.XABSTRACT_FEATURE_CALL__IMPLICIT_FIRST_ARGUMENT) {
+				return new EObjectDiagnosticImpl(Severity.ERROR, IssueCodes.INCOMPATIBLE_TYPES,
+					String.format("Type mismatch: cannot convert implicit first argument from %s to %s",
+						actualType.humanReadableName, expectedType.humanReadableName), expression, null, -1, null);
+			} else {
+				// start of customized code
+
+				val typePair = if (actualType.humanReadableName == expectedType.humanReadableName) {
+						actualType.identifier + " to " + expectedType.identifier
+					} else {
+						actualType.humanReadableName + " to " + expectedType.humanReadableName
+					}
+
+				return new EObjectDiagnosticImpl(Severity.ERROR, IssueCodes.INCOMPATIBLE_TYPES,
+					"Type mismatch: cannot convert from " + typePair, expression, null, -1, null);
+
+				// end of customized code
+			}
+		} else {
+			return new EObjectDiagnosticImpl(Severity.ERROR, IssueCodes.INCOMPATIBLE_TYPES,
+				String.format("Type mismatch: type %s is not applicable at this location",
+					actualType.humanReadableName), expression, null, -1, null);
+		}
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLAssociationValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLAssociationValidator.xtend
@@ -1,6 +1,7 @@
 package hu.elte.txtuml.xtxtuml.validation;
 
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociation
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociationEnd
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUComposition
 import org.eclipse.xtext.validation.Check
 
@@ -31,6 +32,29 @@ class XtxtUMLAssociationValidator extends XtxtUMLClassValidator {
 					" must not be present in an association", it, TU_ASSOCIATION_END__CONTAINER,
 					CONTAINER_END_IN_ASSOCIATION);
 			]
+		}
+	}
+
+	@Check
+	def checkContainerEndMultiplicity(TUAssociationEnd assocEnd) {
+		val multipl = assocEnd.multiplicity;
+		if (assocEnd.container && multipl != null) { // container end with explicit multiplicity
+			warning("The multiplicity of container end " + assocEnd.name +
+				" is implicitly 0..1 – the specified multiplicity will be ignored", assocEnd,
+				TU_ASSOCIATION_END__MULTIPLICITY, WRONG_ASSOCIATION_END_MULTIPLICITY);
+		}
+	}
+
+	@Check
+	def checkMultiplicity(TUAssociationEnd assocEnd) {
+		val multipl = assocEnd.multiplicity;
+		if (multipl != null && !multipl.any) { // explicit, not *
+			val exactlyZero = multipl.lower == 0 && (!multipl.upperSet || !multipl.isUpperInf && multipl.upper == 0);
+			val lowerIsGreaterThanUpper = multipl.upperSet && !multipl.upperInf && multipl.lower > multipl.upper;
+			if (exactlyZero || lowerIsGreaterThanUpper) {
+				warning("The effective multiplicity of association end " + assocEnd.name + " is zero", assocEnd,
+					TU_ASSOCIATION_END__MULTIPLICITY, WRONG_ASSOCIATION_END_MULTIPLICITY);
+			}
 		}
 	}
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLClassValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLClassValidator.xtend
@@ -1,6 +1,7 @@
 package hu.elte.txtuml.xtxtuml.validation;
 
 import com.google.inject.Inject
+import hu.elte.txtuml.xtxtuml.common.XtxtUMLUtils
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUClass
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUClassMember
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUConstructor
@@ -27,26 +28,12 @@ import static hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage.Literals.*
 class XtxtUMLClassValidator extends XtxtUMLFileValidator {
 
 	@Inject extension IQualifiedNameProvider;
+	@Inject extension XtxtUMLUtils;
 
 	@Check
 	def checkNoCycleInClassHiearchy(TUClass clazz) {
-		if (clazz.superClass == null) {
-			return;
-		}
-
-		val visitedClasses = newHashSet;
-		visitedClasses.add(clazz);
-
-		var currentClass = clazz.superClass;
-		while (currentClass != null) {
-			if (visitedClasses.contains(currentClass)) {
-				error("Cycle in hierarchy of class " + clazz.name + " reaching " + currentClass.name,
-					TU_CLASS__SUPER_CLASS, CLASS_HIERARCHY_CYCLE);
-				return;
-			}
-
-			visitedClasses.add(currentClass);
-			currentClass = currentClass.superClass;
+		if (clazz.travelClassHierarchy[false] == null) {
+			error("Cycle in hierarchy of class " + clazz.name, clazz, TU_CLASS__SUPER_CLASS, CLASS_HIERARCHY_CYCLE);
 		}
 	}
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLConnectorValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLConnectorValidator.xtend
@@ -61,7 +61,6 @@ class XtxtUMLConnectorValidator extends XtxtUMLAssociationValidator {
 			}
 		} else { // assembly connector
 			if (compositionOfRoleA == null || compositionOfRoleB == null // roles must be from compositions
-			|| compositionOfRoleA.fullyQualifiedName == compositionOfRoleB.fullyQualifiedName // underlying compositions must be different
 			|| compositionOfRoleA.ends.findFirst[container]?.endClass?.fullyQualifiedName !=
 				compositionOfRoleB.ends.findFirst[container]?.endClass?.fullyQualifiedName // container must be the same
 			) {

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLFileValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLFileValidator.xtend
@@ -1,5 +1,6 @@
 package hu.elte.txtuml.xtxtuml.validation;
 
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUFile
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUModelDeclaration
 import java.util.List
 import java.util.Map
@@ -13,10 +14,29 @@ class XtxtUMLFileValidator extends XtxtUMLExpressionValidator {
 
 	@Check
 	def checkModelDeclarationIsInModelInfoFile(TUModelDeclaration modelDeclaration) {
-		var name = modelDeclaration.eResource?.URI?.lastSegment ?: "";
-		if (name != "model-info.xtxtuml") {
-			error('Model declaration must be specified in "model-info.xtxtuml"', modelDeclaration,
-				TU_MODEL_DECLARATION__MODEL, MISPLACED_MODEL_DECLARATION);
+		if (!isModelInfo(modelDeclaration)) {
+			error("Model declarations must be specified either in 'model-info.xtxtuml' or 'model-info.txtuml'",
+				modelDeclaration, TU_MODEL_DECLARATION__MODEL, MISPLACED_MODEL_DECLARATION);
+		}
+	}
+
+	@Check
+	def checkModelInfoContainsModelDeclaration(TUFile file) {
+		if (isModelInfo(file) && !(file instanceof TUModelDeclaration)) {
+			error("A 'model-info' file must contain exactly one model declaration", file, null,
+				WRONG_MODEL_INFO);
+		}
+	}
+
+	def isModelInfo(TUFile file) {
+		var fileName = file.eResource?.URI?.trimFileExtension?.lastSegment ?: "";
+		return fileName == "model-info";
+	}
+
+	@Check
+	def checkDefaultPackageIsNotUsed(TUFile file) {
+		if (file.name == null) {
+			error("The default package cannot be used in txtUML", file, null, WRONG_PACKAGE);
 		}
 	}
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -17,6 +17,7 @@ class XtxtUMLIssueCodes {
 	public static val NOT_UNIQUE_INITIAL_TRANSITION = ISSUE_CODE_PREFIX + "not_unique_initial_transition";
 	public static val NOT_UNIQUE_TRANSITION_MEMBER = ISSUE_CODE_PREFIX + "not_unique_transition_member";
 	public static val NOT_UNIQUE_PORT_MEMBER = ISSUE_CODE_PREFIX + "not_unique_port_member";
+	public static val NOT_UNIQUE_RECEPTION = ISSUE_CODE_PREFIX + "not_unique_reception";
 
 	// Typing-related issues
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -17,7 +17,6 @@ class XtxtUMLIssueCodes {
 	public static val NOT_UNIQUE_INITIAL_TRANSITION = ISSUE_CODE_PREFIX + "not_unique_initial_transition";
 	public static val NOT_UNIQUE_TRANSITION_MEMBER = ISSUE_CODE_PREFIX + "not_unique_transition_member";
 	public static val NOT_UNIQUE_PORT_MEMBER = ISSUE_CODE_PREFIX + "not_unique_port_member";
-	public static val NOT_UNIQUE_CONNECTOR_END = ISSUE_CODE_PREFIX + "not_unique_connector_end";
 
 	// Typing-related issues
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -38,6 +38,7 @@ class XtxtUMLIssueCodes {
 	// File-related issues
 
 	public static val MISPLACED_MODEL_DECLARATION = ISSUE_CODE_PREFIX + "misplaced_model_declaration";
+	public static val WRONG_MODEL_INFO = ISSUE_CODE_PREFIX + "wrong_model_info";
 
 	// Class-related issues
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -72,6 +72,10 @@ class XtxtUMLIssueCodes {
 	public static val INCOMPATIBLE_PORTS = ISSUE_CODE_PREFIX + "incompatible_ports";
 	public static val NOT_OWNED_PORT = ISSUE_CODE_PREFIX + "not_owned_port";
 
+	// UI-related issues
+	
+	public static val WRONG_PACKAGE = ISSUE_CODE_PREFIX + "wrong_package";
+
 	/**
 	 * Used by {@link XtxtUMLDerivedResourceMarkerCopier} to propagate JtxtUML validation errors to XtxtUML source.
 	 */

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -7,6 +7,10 @@ class XtxtUMLIssueCodes {
 
 	protected static val ISSUE_CODE_PREFIX = "hu.elte.txtuml.xtxtuml.validation.IssueCodes.";
 
+	// Name-related issues
+
+	public static val RESERVED_NAME = ISSUE_CODE_PREFIX + "reserved_name";
+
 	// Uniqueness-related issues
 
 	public static val NOT_UNIQUE_NAME = ISSUE_CODE_PREFIX + "not_unique_name";

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLIssueCodes.xtend
@@ -62,6 +62,7 @@ class XtxtUMLIssueCodes {
 	public static val ASSOCIATION_END_COUNT_MISMATCH = ISSUE_CODE_PREFIX + "association_end_count_mismatch";
 	public static val CONTAINER_END_IN_ASSOCIATION = ISSUE_CODE_PREFIX + "container_end_in_association";
 	public static val CONTAINER_END_COUNT_MISMATCH = ISSUE_CODE_PREFIX + "container_end_count_mismatch";
+	public static val WRONG_ASSOCIATION_END_MULTIPLICITY = ISSUE_CODE_PREFIX + "wrong_association_end_multiplicity";
 
 	// Connector-related issues
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLNameValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLNameValidator.xtend
@@ -1,0 +1,112 @@
+package hu.elte.txtuml.xtxtuml.validation;
+
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAssociationEnd
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUAttribute
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUConnectorEnd
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUConstructor
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUFile
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUModelElement
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUOperation
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUPort
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignalAttribute
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUState
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUTransition
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.emf.ecore.EStructuralFeature
+import org.eclipse.xtext.common.types.JvmFormalParameter
+import org.eclipse.xtext.common.types.TypesPackage
+import org.eclipse.xtext.validation.Check
+import org.eclipse.xtext.xbase.XVariableDeclaration
+import org.eclipse.xtext.xbase.XbasePackage
+
+import static hu.elte.txtuml.xtxtuml.validation.XtxtUMLIssueCodes.*
+import static hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage.Literals.*
+
+class XtxtUMLNameValidator extends AbstractXtxtUMLValidator {
+
+	private static val reservedJavaWords = #["abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+		"class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "false", "final", "finally",
+		"float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native", "new",
+		"null", "package", "private", "protected", "public", "return", "short", "static", "strictfp", "super", "switch",
+		"synchronized", "this", "throw", "throws", "transient", "true", "try", "void", "volatile", "while"];
+
+	@Check
+	def checkPackageNameIsNotReserved(TUFile file) {
+		checkReservedError(file, file.name, TU_FILE__NAME, "package");
+	}
+
+	@Check
+	def checkModelElementNameIsNotReserved(TUModelElement modelElement) {
+		checkReservedError(modelElement, modelElement.name, TU_MODEL_ELEMENT__NAME, "model element");
+	}
+
+	@Check
+	def checkSignalAttributeNameIsNotReserved(TUSignalAttribute attribute) {
+		checkReservedError(attribute, attribute.name, TU_SIGNAL_ATTRIBUTE__NAME, "signal attribute");
+	}
+
+	@Check
+	def checkAttributeNameIsNotReserved(TUAttribute attribute) {
+		checkReservedError(attribute, attribute.name, TU_ATTRIBUTE__NAME, "attribute");
+	}
+
+	@Check
+	def checkConstructorNameIsNotReserved(TUConstructor constructor) {
+		checkReservedError(constructor, constructor.name, TU_CONSTRUCTOR__NAME, "constructor");
+	}
+
+	@Check
+	def checkOperationNameIsNotReserved(TUOperation operation) {
+		checkReservedError(operation, operation.name, TU_OPERATION__NAME, "operation");
+	}
+
+	@Check
+	def checkStateNameIsNotReserved(TUState state) {
+		checkReservedError(state, state.name, TU_STATE__NAME, "state");
+	}
+
+	@Check
+	def checkTransitionNameIsNotReserved(TUTransition transition) {
+		checkReservedError(transition, transition.name, TU_TRANSITION__NAME, "transition");
+	}
+
+	@Check
+	def checkPortNameIsNotReserved(TUPort port) {
+		checkReservedError(port, port.name, TU_CLASS_PROPERTY__NAME, "port");
+	}
+
+	@Check
+	def checkAssociationEndNameIsNotReserved(TUAssociationEnd associationEnd) {
+		checkReservedError(associationEnd, associationEnd.name, TU_CLASS_PROPERTY__NAME, "association end");
+	}
+
+	@Check
+	def checkConnectorEndNameIsNotReserved(TUConnectorEnd connectorEnd) {
+		checkReservedError(connectorEnd, connectorEnd.name, TU_CONNECTOR_END__NAME, "connector end");
+	}
+
+	@Check
+	def checkParameterNameIsNotReserved(JvmFormalParameter parameter) {
+		checkReservedError(parameter, parameter.name, TypesPackage.Literals.JVM_FORMAL_PARAMETER__NAME, "parameter");
+	}
+
+	@Check
+	def checkVariableNameIsNotReserved(XVariableDeclaration variable) {
+		checkReservedError(variable, variable.name, XbasePackage.Literals.XVARIABLE_DECLARATION__NAME, "variable");
+	}
+
+	def protected checkReservedError(EObject element, String name, EStructuralFeature nameFeature, String type) {
+		if (name.isReserved) {
+			error(reservedErrorMessage(type, name), element, nameFeature, RESERVED_NAME);
+		}
+	}
+
+	def protected isReserved(String name) {
+		reservedJavaWords.contains(name)
+	}
+
+	def protected reservedErrorMessage(String type, String name) {
+		"The name of " + type + " " + name + " is invalid – Java reserved words cannot be used as identifiers in txtUML"
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
@@ -39,7 +39,7 @@ import org.eclipse.xtext.validation.Check
 import static hu.elte.txtuml.xtxtuml.validation.XtxtUMLIssueCodes.*
 import static hu.elte.txtuml.xtxtuml.xtxtUML.XtxtUMLPackage.Literals.*
 
-class XtxtUMLUniquenessValidator extends AbstractXtxtUMLValidator {
+class XtxtUMLUniquenessValidator extends XtxtUMLNameValidator {
 
 	@Inject extension IQualifiedNameProvider;
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
@@ -11,10 +11,12 @@ import hu.elte.txtuml.xtxtuml.xtxtUML.TUConnectorEnd
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUConstructor
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUEntryOrExitActivity
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUFile
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUInterface
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUModelElement
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUOperation
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUPort
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUPortMember
+import hu.elte.txtuml.xtxtuml.xtxtUML.TUReception
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignal
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUSignalAttribute
 import hu.elte.txtuml.xtxtuml.xtxtUML.TUState
@@ -65,6 +67,17 @@ class XtxtUMLUniquenessValidator extends AbstractXtxtUMLValidator {
 			error("Duplicate model element " + modelElement.name +
 				optionalCaseInsensitivityWarning(modelElement.name, duplicateName), modelElement, TU_MODEL_ELEMENT__NAME,
 				NOT_UNIQUE_NAME);
+		}
+	}
+
+	@Check
+	def checkReceptionIsUnique(TUReception reception) {
+		val enclosingInterface = reception.eContainer as TUInterface;
+		if (enclosingInterface.receptions.exists [
+			signal.fullyQualifiedName == reception.signal.fullyQualifiedName && it != reception // direct comparison is safe here
+		]) {
+			error("Duplicate reception in interface " + enclosingInterface.name, reception, TU_RECEPTION__SIGNAL,
+				NOT_UNIQUE_RECEPTION);
 		}
 	}
 

--- a/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
+++ b/dev/plugins/hu.elte.txtuml.xtxtuml/src/hu/elte/txtuml/xtxtuml/validation/XtxtUMLUniquenessValidator.xtend
@@ -239,15 +239,11 @@ class XtxtUMLUniquenessValidator extends AbstractXtxtUMLValidator {
 	}
 
 	@Check
-	def checkConnectorEndIsUnique(TUConnectorEnd connectorEnd) {
-		val container = connectorEnd.eContainer as TUConnector;
-		if (container.ends.exists [
-			(name == connectorEnd.name || role?.fullyQualifiedName == connectorEnd.role?.fullyQualifiedName) &&
-				it != connectorEnd // direct comparison is safe here
-		]) {
-			error("Duplicate connector end " + connectorEnd.name + " in connector " + container.name +
-				" – names and roles must be unique among ends of a connector", connectorEnd, TU_CONNECTOR_END__NAME,
-				NOT_UNIQUE_CONNECTOR_END);
+	def checkConnectorEndNamesAreUnique(TUConnectorEnd connectorEnd) {
+		val connector = connectorEnd.eContainer as TUConnector;
+		if (1 < connector.ends.filter[name == connectorEnd.name].length) {
+			error("Connector end " + connectorEnd.name + " in connector " + connector.name +
+				" must have a unique name", connectorEnd, TU_CONNECTOR_END__NAME, NOT_UNIQUE_NAME);
 		}
 	}
 


### PR DESCRIPTION
This pull request is mainly intended to fix various validation-related issues. In addition, some aspects of both the J- and XtxtUML validator has been improved. For more information, see the (full) commit messages.

**Some of the new/improved XtxtUML features in action:**

- Uniqueness validation of class-like entities is case insensitive.
![case-insensitive-uniqueness-validation](https://cloud.githubusercontent.com/assets/13290204/17642769/245eddc0-6154-11e6-818c-52a7efe7900f.png)
![cross-file-case-insensitive-duplication](https://cloud.githubusercontent.com/assets/13290204/18019307/b0f41822-6bdb-11e6-8596-d208e89c9288.png)


- Fully qualified names are used in type mismatch error messages if the simple names of mismatching types are equal.
![fqn-in-type-mismatch-messages](https://cloud.githubusercontent.com/assets/13290204/17642782/566cae50-6154-11e6-9778-529d298061e0.png)

- Java reserved words are no longer allowed as identifiers.
![java-reserved-words](https://cloud.githubusercontent.com/assets/13290204/17642791/783a361a-6154-11e6-8831-9ae7ecf10a09.png)

- Looser grammar, stricter validation of package and model declarations.
![looser-grammar-stricter-validation](https://cloud.githubusercontent.com/assets/13290204/17642800/8d7d193e-6154-11e6-85ef-c17d40361fce.png)

- Model declarations could be placed only in *model-info* files even in the previous implementation. Now, it is also validated that *model-info* files must contain only a model declaration.
![model-info-improvements](https://cloud.githubusercontent.com/assets/13290204/17642810/daa985d0-6154-11e6-99a4-ed17c754887c.png)

- Multiplicity of association ends is now checked.
![multiplicity-validation](https://cloud.githubusercontent.com/assets/13290204/17642812/009be850-6155-11e6-82a9-c79e4533b5a1.png)

- Package and model declarations are now validated.
![package-and-model-declaration](https://cloud.githubusercontent.com/assets/13290204/17642813/114417ea-6155-11e6-85e1-b517c8c6fdab.png)

- Inheritance is now considered in class property accessibility validation.
![property-inheritance](https://cloud.githubusercontent.com/assets/13290204/17642814/26428726-6155-11e6-999b-7835ac8deef4.png)

- Uniqueness validation is extended to receptions.
![uniqueness-of-receptions](https://cloud.githubusercontent.com/assets/13290204/17642816/36730544-6155-11e6-8e1c-5586a7e4273a.png)

<hr>

This pull request:
- resolves #29,
- resolves #40,
- affects #320,
- fixes #343,
- resolves #387,
- resolves #388,
- resolves #390,
- and fixes #426.

It should be noted that technically, the XtxtUML runtime is no longer dependent on the UI, therefore #320 would be resolvable here. However, I would like to create a separate pull request for that, as it is more releng-related.