### PR TITLE
Enable trace logging in producer_consumer demo

### DIFF
--- a/examples/demo/producer_consumer/src/producer_consumer/j/Tester.java
+++ b/examples/demo/producer_consumer/src/producer_consumer/j/Tester.java
@@ -30,7 +30,7 @@ public class Tester {
 		Action.start(c3);
 	}
 
-	public static void main(String[] init) {
-		ModelExecutor.create().run(Tester::init);
+	public static void main(String[] args) {
+		ModelExecutor.create().setTraceLogging(true).run(Tester::init);
 	}
 }

--- a/examples/demo/producer_consumer/src/producer_consumer/x/Tester.java
+++ b/examples/demo/producer_consumer/src/producer_consumer/x/Tester.java
@@ -31,6 +31,6 @@ public class Tester {
 	}
 
 	public static void main(String[] args) {
-		ModelExecutor.create().run(Tester::init);
+		ModelExecutor.create().setTraceLogging(true).run(Tester::init);
 	}
 }


### PR DESCRIPTION
As there's no action logging in *producer_consumer*, trace logging should be enabled to make its execution observable by the user.