### PR TITLE
Diagram visualization context menu

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.papyrus/META-INF/MANIFEST.MF
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/META-INF/MANIFEST.MF
@@ -35,7 +35,8 @@ Require-Bundle:
  org.eclipse.emf.ecore,
  org.eclipse.jdt.ui,
  com.google.guava,
- hu.elte.txtuml.utils.eclipse
+ hu.elte.txtuml.utils.eclipse,
+ org.eclipse.core.expressions
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: hu.elte.txtuml.export.papyrus,

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/plugin.xml
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/plugin.xml
@@ -27,6 +27,20 @@
             id="hu.elte.txtuml.export.papyrus.txtUMLVisualize"
             name="txtUMLVisualize">
       </command>
+	  <command
+            defaultHandler="hu.elte.txtuml.export.papyrus.handlers.TxtUMLVisualizeSelectedDiagramsHandler"
+            id="hu.elte.txtuml.export.papyrus.txtUMLVisualizeSelectedDiagram"
+            name="txtUMLVisualizeSelectedDiagram">
+      </command>
+   </extension>
+   <extension point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            namespace="hu.elte.txtuml.export.papyrus"
+            id="hu.elte.txtuml.export.papyrus.DiagramDescriptionTester"
+            properties="hasDescriptionType"
+            type="org.eclipse.jdt.core.ICompilationUnit"
+            class="hu.elte.txtuml.export.papyrus.handlers.DiagramDescriptionTester">
+     </propertyTester>
    </extension>
    <extension
          point="org.eclipse.ui.menus">
@@ -91,6 +105,25 @@
             </command>
          </menu>
       </menuContribution>
+	  
+	  <menuContribution
+      locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
+         <command
+               commandId="hu.elte.txtuml.export.papyrus.txtUMLVisualizeSelectedDiagram"
+               icon="icons/txtUML_papyrus.png"
+               label="Visualize diagram"
+			   style="push">
+			   <visibleWhen>
+			       <with variable="activeMenuSelection">
+				       <iterate ifEmpty="false" operator="and">
+					       <adapt type="org.eclipse.jdt.core.ICompilationUnit">
+						       <test property="hu.elte.txtuml.export.papyrus.hasDescriptionType"/>
+						   </adapt>
+				       </iterate>
+				   </with>
+			   </visibleWhen>
+         </command>
+      </menuContribution>
    </extension>
    <extension
          point="org.eclipse.ui.preferencePages">
@@ -105,6 +138,9 @@
       <initializer
             class="hu.elte.txtuml.export.papyrus.preferences.PreferencesInitializer">
       </initializer>
+   </extension>
+   <extension point="org.eclipse.ui.startup">
+      <startup class="hu.elte.txtuml.export.papyrus.handlers.Startup"/>
    </extension>
 
 </plugin>

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/plugin.xml
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/plugin.xml
@@ -105,24 +105,24 @@
             </command>
          </menu>
       </menuContribution>
-	  
-	  <menuContribution
-      locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
-         <command
-               commandId="hu.elte.txtuml.export.papyrus.txtUMLVisualizeSelectedDiagram"
-               icon="icons/txtUML_papyrus.png"
-               label="Visualize diagram"
-			   style="push">
-			   <visibleWhen>
-			       <with variable="activeMenuSelection">
-				       <iterate ifEmpty="false" operator="and">
-					       <adapt type="org.eclipse.jdt.core.ICompilationUnit">
-						       <test property="hu.elte.txtuml.export.papyrus.hasDescriptionType"/>
-						   </adapt>
-				       </iterate>
-				   </with>
-			   </visibleWhen>
-         </command>
+
+      <menuContribution 
+          locationURI="popup:org.eclipse.ui.navigator.ProjectExplorer#PopupMenu?before=additions">
+          <command
+              commandId="hu.elte.txtuml.export.papyrus.txtUMLVisualizeSelectedDiagram"
+              icon="icons/txtUML_papyrus.png"
+              label="Visualize diagram"
+              style="push">
+              <visibleWhen>
+                  <with variable="activeMenuSelection">
+                     <iterate ifEmpty="false" operator="and">
+                          <adapt type="org.eclipse.jdt.core.ICompilationUnit">
+                              <test property="hu.elte.txtuml.export.papyrus.hasDescriptionType"/>
+                          </adapt>
+                      </iterate>
+                  </with>
+              </visibleWhen>
+          </command>
       </menuContribution>
    </extension>
    <extension

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/DiagramDescriptionTester.java
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/DiagramDescriptionTester.java
@@ -1,0 +1,43 @@
+package hu.elte.txtuml.export.papyrus.handlers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaModelException;
+
+import hu.elte.txtuml.api.layout.Diagram;
+
+public class DiagramDescriptionTester extends PropertyTester {
+
+	@Override
+	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+		ICompilationUnit compilationUnit = (ICompilationUnit) receiver;
+		if ("hasDescriptionType".equals(property)) {
+			List<IType> types = null;
+			try {
+				types = Arrays.asList(compilationUnit.getAllTypes());
+			} catch (JavaModelException ex) {
+				return false;
+			}
+			boolean hasDiagramType = types.stream().anyMatch(ty -> {
+				ITypeHierarchy tyHierarchy = null;
+				try {
+					tyHierarchy = ty.newSupertypeHierarchy(null);
+				} catch (JavaModelException ex) {
+					return false;
+				}
+				return Stream.of(tyHierarchy.getAllSupertypes(ty))
+						.anyMatch(superTy -> superTy.getFullyQualifiedName().equals(Diagram.class.getCanonicalName()));
+			});
+
+			return expectedValue == null ? hasDiagramType : hasDiagramType == ((Boolean) expectedValue).booleanValue();
+		}
+		return false;
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/Startup.java
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/Startup.java
@@ -1,0 +1,14 @@
+package hu.elte.txtuml.export.papyrus.handlers;
+
+import org.eclipse.ui.IStartup;
+
+/**
+ * Necessary to make the property tester work from the start.
+ */
+public class Startup implements IStartup {
+
+	@Override
+	public void earlyStartup() {
+	}
+
+}

--- a/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/TxtUMLVisualizeSelectedDiagramsHandler.java
+++ b/dev/plugins/hu.elte.txtuml.export.papyrus/src/hu/elte/txtuml/export/papyrus/handlers/TxtUMLVisualizeSelectedDiagramsHandler.java
@@ -1,0 +1,53 @@
+package hu.elte.txtuml.export.papyrus.handlers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.ui.handlers.HandlerUtil;
+
+import hu.elte.txtuml.export.papyrus.wizardz.TxtUMLVisuzalizeWizard;
+import hu.elte.txtuml.export.papyrus.wizardz.VisualizeTxtUMLPage;
+
+public class TxtUMLVisualizeSelectedDiagramsHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		TxtUMLVisuzalizeWizard wizard = new TxtUMLVisuzalizeWizard();
+		WizardDialog wizardDialog = new WizardDialog(null, wizard);
+		wizardDialog.create();
+
+		VisualizeTxtUMLPage page = ((VisualizeTxtUMLPage) wizardDialog.getSelectedPage());
+
+		// get selected files
+		ISelection selection = HandlerUtil.getCurrentSelection(event);
+		IStructuredSelection strSelection = (IStructuredSelection) selection;
+
+		List<ICompilationUnit> selectedCompilationUnits = new ArrayList<>();
+		Stream.of(strSelection.toArray()).forEach(s -> selectedCompilationUnits
+				.add((ICompilationUnit) ((IAdaptable) s).getAdapter(ICompilationUnit.class)));
+		try {
+			List<IType> types = new ArrayList<>();
+			for (ICompilationUnit cu : selectedCompilationUnits) {
+				types.addAll(Arrays.asList(cu.getTypes()));
+			}
+			page.selectElementsInDiagramTree(types.toArray());
+		} catch (JavaModelException ex) {
+		}
+
+		wizardDialog.open();
+		return null;
+	}
+
+}


### PR DESCRIPTION
This pull request intends to resolve #463.

- A 'Visualize diagram' option is added to the context menu of diagram descriptions in the project explorer.
- This option is only accessible in case of descriptions, otherwise it is not visible.
- Multiple selection is allowed.
- Choosing the visualize option the visualization wizard should appear, and the selected descriptions should be checked in the diagram selection tree.