### PR TITLE
This solves issue 450:

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/utils/MultiplicityProvider.java
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/utils/MultiplicityProvider.java
@@ -59,6 +59,17 @@ public class MultiplicityProvider {
 	public static boolean isOneToUnlimited(TypeDeclaration typeDeclaration) {
 		return SharedUtils.typeIsAssignableFrom(typeDeclaration, Multiplicity.OneToUnlimited.class);
 	}
+	/**
+	 * Decides if the txtUML element represented by the specified class has *..*
+	 * multiplicity.
+	 * 
+	 * @param specifiedClass
+	 *            The specified class representing a txtUML element.
+	 * @return The decision.
+	 */
+	public static boolean isMultiple(TypeDeclaration typeDeclaration) {
+		return SharedUtils.typeIsAssignableFrom(typeDeclaration, Multiplicity.MinToMax.class);
+	}
 
 	private static Integer getExplicitMultiplicity(TypeDeclaration typeDeclaration, String annotationName) {
 		for (Object modifier : typeDeclaration.modifiers()) {
@@ -102,7 +113,7 @@ public class MultiplicityProvider {
 		if (explicitLowerBound != null) {
 			return explicitLowerBound;
 		}
-		if (isZeroToOne(typeDeclaration) || isZeroToUnlimited(typeDeclaration))
+		if (isZeroToOne(typeDeclaration) || isZeroToUnlimited(typeDeclaration)|| isMultiple(typeDeclaration))
 			return 0;
 		else
 			return 1;
@@ -121,7 +132,7 @@ public class MultiplicityProvider {
 		if (explicitUpperBound != null) {
 			return explicitUpperBound;
 		}
-		if (isOneToUnlimited(typeDeclaration) || isZeroToUnlimited(typeDeclaration))
+		if (isOneToUnlimited(typeDeclaration) || isZeroToUnlimited(typeDeclaration)|| isMultiple(typeDeclaration))
 			return org.eclipse.uml2.uml.LiteralUnlimitedNatural.UNLIMITED;
 		else
 			return 1;


### PR DESCRIPTION
When a Multiple or HiddenMultiple multiplicity without Min and / or Max
annotation is exported to uml2 model, the multiplicity is 1..1 instead
of 0..* as documented in the Language Guide.

the handeling was written but not referenced in MultiplicituProvider
class so I fixed that by adding the function isMultiple.