### PR TITLE
Configurable FMU association ends

### DIFF
--- a/dev/plugins/hu.elte.txtuml.api.deployment/src/hu/elte/txtuml/api/deployment/fmi/FMUAssociationEnd.java
+++ b/dev/plugins/hu.elte.txtuml.api.deployment/src/hu/elte/txtuml/api/deployment/fmi/FMUAssociationEnd.java
@@ -1,0 +1,11 @@
+package hu.elte.txtuml.api.deployment.fmi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+import hu.elte.txtuml.api.model.AssociationEnd;
+
+@Target(ElementType.TYPE)
+public @interface FMUAssociationEnd {
+	Class<? extends AssociationEnd<?, ?>> fmuAssociationEnd();
+}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/cpp-runtime/ievent.hpp
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/cpp-runtime/ievent.hpp
@@ -45,21 +45,21 @@ public:
 	}
 
 public:
-	static void invalidatesEvent(ES::EventRef& event) {
+	static void invalidatesEvent(ES::SharedPtr<IEvent<DerivedBase>>& event) {
 		event->setTargetSM(nullptr);
 	}
 
-	static bool eventIsValid(const ES::EventRef& event) {
+	static bool eventIsValid(const ES::SharedPtr<IEvent<DerivedBase>>& event) {
 		return event->getTargetSM() != nullptr;
 	}
 
 };
 
 
-template<typename Derived>
+template<typename DerivedBase>
 class SpecialEventChecker {
 public:
-	bool operator() (const ES::EventRef& e) {
+	bool operator() (const ES::SharedPtr<const IEvent<DerivedBase>>& e) {
 		return e->getSpecialType() != SpecialSignalType::NoSpecial;
 	}
 };

--- a/dev/plugins/hu.elte.txtuml.export.cpp/cpp-runtime/statemachinebase.hpp
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/cpp-runtime/statemachinebase.hpp
@@ -53,7 +53,8 @@ class StateMachineBase
 public:
  virtual bool process_event(ES::EventRef)=0;
  virtual void setInitialState()=0;
- virtual void Initialize(ES::EventRef) = 0;
+ virtual void initialize(ES::EventRef) = 0;
+ virtual void finalize(ES::EventRef) = 0;
  virtual ~StateMachineBase(){}
 protected:
   bool defaultGuard(ES::EventRef){return true;}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/fmuResources/FMUEnvironment.cpp
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/fmuResources/FMUEnvironment.cpp
@@ -57,7 +57,10 @@ public:
    void processInitTransition(ES::EventRef) {
    }
    
-   void Initialize(ES::EventRef) {
+   void initialize(ES::EventRef) {
+   }
+
+   void finalize(ES::EventRef) {
    }
 
 };

--- a/dev/plugins/hu.elte.txtuml.export.cpp/fmuResources/FMUEnvironment.hpp
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/fmuResources/FMUEnvironment.hpp
@@ -13,7 +13,7 @@ class FMUEnvironment : public StateMachineBase, public IStateMachine {
     bool process_event(ES::EventRef) = 0;
     void setInitialState() = 0;
 
-    Model::AssociationEnd<$fmuclass> LanderWorld_lander = AssociationEnd< $fmuclass > (1, 1);
+    Model::AssociationEnd<$fmuclass> $fmuassociationend = AssociationEnd< $fmuclass > (1, 1);
     
     template<typename EndPointName>
     void link(typename EndPointName::EdgeType*);

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/ActivityExportResult.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/ActivityExportResult.java
@@ -1,0 +1,36 @@
+package hu.elte.txtuml.export.cpp;
+
+public class ActivityExportResult {
+	
+	public static ActivityExportResult emptyResult() {
+		return new ActivityExportResult();
+	}
+	
+	public ActivityExportResult() {
+		activitySource = new StringBuilder("");
+		containsSignalAccess = false;
+	}
+	
+	public void appendToSource(String source) {
+		activitySource.append(source);
+	}
+	
+	public void reduceSource(String regex) {
+		activitySource = new StringBuilder(activitySource.toString().replaceAll(regex, ""));
+	}
+	
+	public void setSignalReferenceContainment() {
+		containsSignalAccess = true;
+	}
+	
+	public String getActivitySource() {
+		return activitySource.toString();
+	}
+	
+	public Boolean sourceHasSignalReference() {
+		return containsSignalAccess;
+	}
+	
+	private StringBuilder activitySource;
+	private Boolean containsSignalAccess;
+}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/CppExporterUtils.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/CppExporterUtils.java
@@ -189,7 +189,7 @@ public class CppExporterUtils {
 		String body = "";
 		for (Operation operation : factoryClass.getOperations()) {
 			if (isConstructor(operation)) {
-				body = activityExporter.createFunctionBody(getOperationActivity(operation)).toString();
+				body = activityExporter.createFunctionBody(getOperationActivity(operation)).getActivitySource();
 
 			}
 		}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/activity/ActivityExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/activity/ActivityExporter.java
@@ -12,12 +12,14 @@ import org.eclipse.uml2.uml.ActivityEdge;
 import org.eclipse.uml2.uml.ActivityNode;
 import org.eclipse.uml2.uml.AddStructuralFeatureValueAction;
 import org.eclipse.uml2.uml.AddVariableValueAction;
+import org.eclipse.uml2.uml.Behavior;
 import org.eclipse.uml2.uml.CallOperationAction;
 import org.eclipse.uml2.uml.ConditionalNode;
 import org.eclipse.uml2.uml.CreateLinkAction;
 import org.eclipse.uml2.uml.CreateObjectAction;
 import org.eclipse.uml2.uml.DestroyLinkAction;
 import org.eclipse.uml2.uml.DestroyObjectAction;
+import org.eclipse.uml2.uml.ExpansionRegion;
 import org.eclipse.uml2.uml.LoopNode;
 import org.eclipse.uml2.uml.OutputPin;
 import org.eclipse.uml2.uml.ReadLinkAction;
@@ -27,12 +29,13 @@ import org.eclipse.uml2.uml.StartClassifierBehaviorAction;
 import org.eclipse.uml2.uml.StartObjectBehaviorAction;
 import org.eclipse.uml2.uml.TestIdentityAction;
 import org.eclipse.uml2.uml.UMLPackage;
-import org.eclipse.uml2.uml.ExpansionRegion;
 
+import hu.elte.txtuml.export.cpp.ActivityExportResult;
 import hu.elte.txtuml.export.cpp.CppExporterUtils;
 import hu.elte.txtuml.export.cpp.templates.activity.ActivityTemplates;
 
 //import hu.elte.txtuml.utils.Logger;
+
 
 public class ActivityExporter {
 
@@ -49,6 +52,8 @@ public class ActivityExporter {
 	private ReturnNodeExporter returnNodeExporter;
 
 	private List<String> createdClassDependencies;
+	
+	private ActivityExportResult activityExportResult;
 
 	public ActivityExporter() {
 	}
@@ -73,11 +78,19 @@ public class ActivityExporter {
 				returnNodeExporter);
 
 	}
-
-	public String createFunctionBody(Activity activity) {
+	public ActivityExportResult createFunctionBody(Behavior behavior) {
+		if(behavior != null && behavior.eClass().equals(UMLPackage.Literals.ACTIVITY)) {
+			return createFunctionBody((Activity) behavior);
+		} else {
+			return ActivityExportResult.emptyResult();
+		}
+	}
+	
+	private ActivityExportResult createFunctionBody(Activity activity){	
+		assert(activity != null);
+		activityExportResult = new ActivityExportResult();	
 		init();
 		ActivityNode startNode = null;
-		StringBuilder source = new StringBuilder("");
 		for (ActivityNode node : activity.getOwnedNodes()) {
 			if (node.eClass().equals(UMLPackage.Literals.INITIAL_NODE)) {
 				startNode = node;
@@ -85,22 +98,17 @@ public class ActivityExporter {
 			}
 		}
 
-		source.append(controlNodeExporter.createStructuredActivityNodeVariables(activity.getVariables()));
-		source.append(createActivityPartCode(startNode));
-		source.append(returnNodeExporter.createReturnParamaterCode());
+		activityExportResult.appendToSource(controlNodeExporter.createStructuredActivityNodeVariables(activity.getVariables()));
+		activityExportResult.appendToSource(createActivityPartCode(startNode));
+		activityExportResult.appendToSource(returnNodeExporter.createReturnParamaterCode());
 
-		String reducedSource = source.toString();
 		for (VariableInfo varInfo : userVariableExporter.getElements()) {
 			if (!varInfo.isUsed()) {
-				reducedSource = reducedSource.replaceAll(ActivityTemplates.declareRegex(varInfo.getName()), "");
-				reducedSource = reducedSource.replaceAll(ActivityTemplates.setRegex(varInfo.getName()), "");
+				activityExportResult.reduceSource(ActivityTemplates.declareRegex(varInfo.getName()));
+				activityExportResult.reduceSource(ActivityTemplates.setRegex(varInfo.getName()));
 			}
 		}
-		return reducedSource;
-	}
-
-	public boolean isContainsSignalAccess() {
-		return callOperationExporter.isUsedSignalParameter();
+		return activityExportResult;
 	}
 
 	public boolean isContainsTimerOperation() {
@@ -196,7 +204,11 @@ public class ActivityExporter {
 		} else if (node.eClass().equals(UMLPackage.Literals.START_OBJECT_BEHAVIOR_ACTION)) {
 			source.append(objectActionExporter.createStartObjectActionCode((StartObjectBehaviorAction) node));
 		} else if (node.eClass().equals(UMLPackage.Literals.CALL_OPERATION_ACTION)) {
-			source.append(callOperationExporter.createCallOperationActionCode((CallOperationAction) node));
+			CallOperationAction callAction = (CallOperationAction) node;
+			if (callAction.getOperation().getName().equals(ActivityTemplates.GetSignalFunctionName)) {
+				activityExportResult.setSignalReferenceContainment();
+			}
+			source.append(callOperationExporter.createCallOperationActionCode(callAction));
 
 		} else if (node.eClass().equals(UMLPackage.Literals.ADD_VARIABLE_VALUE_ACTION)) {
 			AddVariableValueAction avva = (AddVariableValueAction) node;

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/activity/CallOperationExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/activity/CallOperationExporter.java
@@ -22,7 +22,6 @@ import hu.elte.txtuml.export.cpp.templates.structual.VariableTemplates;
 
 class CallOperationExporter {
 
-	private boolean containsSignalAcces;
 	private boolean containsTimerOperator;
 
 	private OutVariableExporter tempVariableExporter;
@@ -33,17 +32,12 @@ class CallOperationExporter {
 	public CallOperationExporter(OutVariableExporter tempVariableExporter,
 			Map<CallOperationAction, OutputPin> returnOutputsToCallActions,
 			ActivityNodeResolver activityExportResolver) {
-		containsSignalAcces = false;
 		containsTimerOperator = false;
 		declaredTempVariables = new HashSet<String>();
 
 		this.tempVariableExporter = tempVariableExporter;
 		this.returnOutputsToCallActions = returnOutputsToCallActions;
 		this.activityExportResolver = activityExportResolver;
-	}
-
-	public boolean isUsedSignalParameter() {
-		return containsSignalAcces;
 	}
 
 	public boolean isInvokedTimerOperation() {
@@ -82,7 +76,6 @@ class CallOperationExporter {
 		}
 
 		if (node.getOperation().getName().equals(ActivityTemplates.GetSignalFunctionName)) {
-			containsSignalAcces = true;
 			return ActivityTemplates.getRealSignal(returnPin.getType().getName(),
 					tempVariableExporter.getRealVariableName(returnPin));
 		}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/EntryExitFunctionExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/EntryExitFunctionExporter.java
@@ -1,13 +1,16 @@
 package hu.elte.txtuml.export.cpp.statemachine;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
-import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.Behavior;
 import org.eclipse.uml2.uml.State;
-import org.eclipse.uml2.uml.UMLPackage;
 
+import hu.elte.txtuml.export.cpp.ActivityExportResult;
 import hu.elte.txtuml.export.cpp.activity.ActivityExporter;
+import hu.elte.txtuml.export.cpp.templates.GenerationNames;
+import hu.elte.txtuml.export.cpp.templates.GenerationNames.StateMachineMethodNames;
+import hu.elte.txtuml.export.cpp.templates.activity.ActivityTemplates;
 import hu.elte.txtuml.export.cpp.templates.statemachine.EventTemplates;
 import hu.elte.txtuml.export.cpp.templates.structual.FunctionTemplates;
 import hu.elte.txtuml.utils.Logger;
@@ -16,11 +19,11 @@ import hu.elte.txtuml.utils.Pair;
 class EntryExitFunctionDescription {
 
 	public EntryExitFunctionDescription(String stateName, String functionName, String functionBody,
-			boolean containsSignalAccess) {
+			boolean containsEventParamReference) {
 		this.stateName = stateName;
 		this.functionName = functionName;
 		this.functionBody = functionBody;
-		this.containsSignalAccess = containsSignalAccess;
+		this.containsEventParamReference = containsEventParamReference;
 	}
 
 	public String getStateName() {
@@ -36,13 +39,13 @@ class EntryExitFunctionDescription {
 	}
 
 	public boolean getContainsSignalAccess() {
-		return containsSignalAccess;
+		return containsEventParamReference;
 	}
 
 	private String stateName;
 	private String functionName;
 	private String functionBody;
-	private boolean containsSignalAccess;
+	private boolean containsEventParamReference;
 
 }
 
@@ -102,9 +105,9 @@ public class EntryExitFunctionExporter {
 
 	private void createFuncTypeMap(FuncTypeEnum funcType) {
 		List<EntryExitFunctionDescription> functionList = new LinkedList<EntryExitFunctionDescription>();
-		String source = "";
-		String name = "";
 		for (State item : stateList) {
+			String source = "";
+			String name = "";
 			Behavior behavior = null;
 			String unknownName = null;
 			switch (funcType) {
@@ -119,14 +122,39 @@ public class EntryExitFunctionExporter {
 				break;
 			}
 			}
+			ActivityExportResult activityResult = new ActivityExportResult();
+			activityResult = activityExporter.createFunctionBody(behavior);
 
-			if (behavior != null) {
-				if (behavior.eClass().equals(UMLPackage.Literals.ACTIVITY)) {
-					source = activityExporter.createFunctionBody((Activity) behavior).toString();
-					name = item.getName() + "_" + unknownName;
-					functionList.add(new EntryExitFunctionDescription(item.getName(), name, source.toString(),
-							activityExporter.isContainsSignalAccess()));
+			if (item.isComposite()) {
+				String compositeRelatedCode = "";
+				switch (funcType) {
+				case Entry:
+					compositeRelatedCode = ActivityTemplates.simpleIf(GenerationNames.CurrentMachineName,
+							ActivityTemplates.operationCallOnPointerVariable(GenerationNames.CurrentMachineName,
+									StateMachineMethodNames.InitializeFunctionName,
+									Arrays.asList(EventTemplates.EventFParamName)));
+					source = activityResult.getActivitySource() + compositeRelatedCode;
+
+					break;
+				case Exit:
+					compositeRelatedCode = ActivityTemplates.simpleIf(GenerationNames.CurrentMachineName,
+							ActivityTemplates.operationCallOnPointerVariable(GenerationNames.CurrentMachineName,
+									StateMachineMethodNames.FinalizeFunctionName,
+									Arrays.asList(EventTemplates.EventFParamName)));
+					source = compositeRelatedCode + activityResult.getActivitySource();
+					break;
+				default:
+					break;
 				}
+
+			} else {
+				source = activityResult.getActivitySource();
+			}
+			if (source != "") {
+				name = item.getName() + "_" + unknownName;
+				functionList.add(new EntryExitFunctionDescription(item.getName(), name, source,
+						item.isComposite() || activityResult.sourceHasSignalReference()));
+
 			}
 		}
 

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/GuardExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/GuardExporter.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.uml2.uml.Activity;
 import org.eclipse.uml2.uml.Constraint;
 import org.eclipse.uml2.uml.OpaqueExpression;
 import org.eclipse.uml2.uml.Pseudostate;
@@ -13,6 +12,7 @@ import org.eclipse.uml2.uml.Transition;
 import org.eclipse.uml2.uml.UMLPackage;
 import org.eclipse.uml2.uml.ValueSpecification;
 
+import hu.elte.txtuml.export.cpp.ActivityExportResult;
 import hu.elte.txtuml.export.cpp.activity.ActivityExporter;
 import hu.elte.txtuml.export.cpp.templates.activity.OperatorTemplates;
 import hu.elte.txtuml.export.cpp.templates.statemachine.StateMachineTemplates;
@@ -71,27 +71,26 @@ public class GuardExporter extends ActivityExporter {
 	public String defnieGuardFunctions(String className) {
 		StringBuilder source = new StringBuilder("");
 		for (Entry<Constraint, String> guardEntry : getGuards().entrySet()) {
-			String body = getGuardFromValueSpecification(guardEntry.getKey().getSpecification());
-			source.append(StateMachineTemplates.guardDefinition(guardEntry.getValue(), body, className,
-					isContainsSignalAccess()));
+			
+			ValueSpecification guard = guardEntry.getKey().getSpecification();
+			ActivityExportResult activityResult = new ActivityExportResult();
+			if (guard != null) {
+				if (guard.eClass().equals(UMLPackage.Literals.OPAQUE_EXPRESSION)) {
+					OpaqueExpression expression = (OpaqueExpression) guard;
+					activityResult = createFunctionBody(expression.getBehavior());
+					source.append(StateMachineTemplates.guardDefinition(guardEntry.getValue(), activityResult.getActivitySource(), className,
+							activityResult.sourceHasSignalReference()));
+					
+				} else {
+					source.append(StateMachineTemplates.guardDefinition(guardEntry.getValue(), "UNKNOWN_GUARD_TYPE", className, false));
+				}
+			}			
+			
+			
+
 		}
 
 		return source.toString();
-	}
-
-	public String getGuardFromValueSpecification(ValueSpecification guard) {
-		String source = "";
-		if (guard != null) {
-			if (guard.eClass().equals(UMLPackage.Literals.OPAQUE_EXPRESSION)) {
-				OpaqueExpression expression = (OpaqueExpression) guard;
-				if (expression.getBehavior() != null
-						&& expression.getBehavior().eClass().equals(UMLPackage.Literals.ACTIVITY))
-					source = createFunctionBody((Activity) expression.getBehavior()).toString();
-			} else {
-				source = "UNKNOWN_GUARD_TYPE";
-			}
-		}
-		return source;
 	}
 
 	public String calculateSmElseGuard(Transition elseTransition) {

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/StateMachineExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/StateMachineExporter.java
@@ -9,6 +9,7 @@ import org.eclipse.uml2.uml.StateMachine;
 import hu.elte.txtuml.export.cpp.templates.statemachine.StateMachineTemplates;
 import hu.elte.txtuml.utils.Pair;
 import org.eclipse.uml2.uml.Element;
+import org.eclipse.uml2.uml.Pseudostate;
 
 public class StateMachineExporter extends StateMachineExporterBase {
 
@@ -44,17 +45,18 @@ public class StateMachineExporter extends StateMachineExporterBase {
 	public String createStateMachineRelatedCppSourceCodes() {
 		StringBuilder source = new StringBuilder("");
 		source.append(createTransitionTableInitRelatedCodes());
+		Pseudostate initialStateName = getInitialState(stateMachineRegion);
 		if (submachineMap.isEmpty()) {
 			source.append(StateMachineTemplates.simpleStateMachineInitializationDefinition(ownerClassName,
-					getInitialStateName(), true, poolId));
+					initialStateName.getName(), true, poolId));
 			source.append(StateMachineTemplates.simpleStateMachineFixFunctionDefinitions(ownerClassName,
-					getInitialStateName(), false));
+					initialStateName.getName(), false));
 
 		} else {
 			source.append(StateMachineTemplates.hierachialStateMachineInitialization(ownerClassName,
-					getInitialStateName(), true, poolId, getEventSubMachineNameMap()));
+					initialStateName.getName(), true, poolId, getEventSubMachineNameMap()));
 			source.append(StateMachineTemplates.hiearchialStateMachineFixFunctionDefinitions(ownerClassName,
-					getInitialStateName(), false));
+					initialStateName.getName(), false));
 
 		}
 		source.append(guardExporter.defnieGuardFunctions(ownerClassName));
@@ -65,14 +67,19 @@ public class StateMachineExporter extends StateMachineExporterBase {
 		source.append(StateMachineTemplates.entry(ownerClassName,
 				createStateActionMap(entryExitFunctionExporter.getEntryMap())) + "\n");
 		source.append(
-				StateMachineTemplates.exit(ownerClassName, createStateActionMap(entryExitFunctionExporter.getExitMap()))
+				StateMachineTemplates.exit(ownerClassName, 
+						createStateActionMap(entryExitFunctionExporter.getExitMap()))
 						+ "\n");
+		
+		source.append(StateMachineTemplates.finalizeFunctionDef(ownerClassName));
+		source.append(StateMachineTemplates.initializeFunctionDef(ownerClassName, getInitialTransition(stateMachineRegion).getName()));
+
 
 		return source.toString();
 	}
 
 	public String createStateEnumCode() {
-		return StateMachineTemplates.stateEnum(stateList, getInitialStateName());
+		return StateMachineTemplates.stateEnum(stateList, getInitialState(stateMachineRegion).getName());
 	}
 
 	public boolean ownSubMachine() {

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/StateMachineExporterBase.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/StateMachineExporterBase.java
@@ -140,7 +140,7 @@ public class StateMachineExporterBase {
 		submachineMap = getSubMachines();
 		subSubMachines = new ArrayList<String>();
 		guardExporter = new GuardExporter();
-		transitionExporter = new TransitionExporter(ownerClassName, stateMachineRegion.getTransitions(), getInitialStateName(), guardExporter);
+		transitionExporter = new TransitionExporter(ownerClassName, stateMachineRegion.getTransitions(), guardExporter);
 		entryExitFunctionExporter = new EntryExitFunctionExporter(ownerClassName, stateList);
 		entryExitFunctionExporter.createEntryFunctionTypeMap();
 		entryExitFunctionExporter.createExitFunctionTypeMap();
@@ -185,10 +185,6 @@ public class StateMachineExporterBase {
 		return eventSubMachineMap;
 	}
 
-	protected String getInitialStateName() {
-		return initialState.getName();
-	}
-
 	protected void createStateList() {
 		stateList = new ArrayList<State>();
 		for (Vertex item : stateMachineRegion.getSubvertices()) {
@@ -196,5 +192,30 @@ public class StateMachineExporterBase {
 				stateList.add((State) item);
 			}
 		}
+	}
+	
+	protected static Pseudostate getInitialState(Region stateMachineRegion) {
+		for (Vertex item : stateMachineRegion.getSubvertices()) {
+			if (item.eClass().equals(UMLPackage.Literals.PSEUDOSTATE)) {
+				Pseudostate pseduoState = (Pseudostate) item;
+				if (pseduoState.getKind().equals(PseudostateKind.INITIAL_LITERAL)) {
+					return (Pseudostate) item;
+				}
+
+			}
+		}		
+		return null;
+	}
+	
+	protected static Transition getInitialTransition(Region stateMachineRegion) {
+		Pseudostate initialState = getInitialState(stateMachineRegion);
+		if (initialState != null) {
+			for (Transition transition : stateMachineRegion.getTransitions()) {
+				if(transition.getSource().equals(initialState)) {
+					return transition;
+				}
+			}
+		}		
+		return null;
 	}
 }

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/SubStateMachineExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/statemachine/SubStateMachineExporter.java
@@ -72,7 +72,7 @@ public class SubStateMachineExporter extends StateMachineExporterBase {
 		List<String> params = new ArrayList<String>();
 		params.add(parentClassName);
 		publicParts.append(ConstructorTemplates.constructorDecl(ownerClassName, params));
-		publicParts.append(StateMachineTemplates.stateEnum(stateList, getInitialStateName()));
+		publicParts.append(StateMachineTemplates.stateEnum(stateList, getInitialState(stateMachineRegion).getName()));
 
 		if (submachineMap.isEmpty()) {
 			source = HeaderTemplates.simpleSubStateMachineClassHeader(dependency.toString(), ownerClassName,
@@ -89,12 +89,13 @@ public class SubStateMachineExporter extends StateMachineExporterBase {
 	private String createSubSmClassCppSource() {
 		StringBuilder source = new StringBuilder("");
 		source.append(createTransitionTableInitRelatedCodes());
+		String initialStateName =  getInitialState(stateMachineRegion).getName();
 		if (submachineMap.isEmpty()) {
 			source.append(ConstructorTemplates.simpleSubStateMachineClassConstructor(ownerClassName, parentClassName,
-					stateMachineMap, getInitialStateName()));
+					stateMachineMap, initialStateName));
 		} else {
 			source.append(ConstructorTemplates.hierarchicalSubStateMachineClassConstructor(ownerClassName,
-					parentClassName, stateMachineMap, getInitialStateName(), getEventSubMachineNameMap()));
+					parentClassName, stateMachineMap, initialStateName, getEventSubMachineNameMap()));
 		}
 		
 		StringBuilder subSmSpec = new StringBuilder(entryExitFunctionExporter.createEntryFunctionsDef());
@@ -106,7 +107,8 @@ public class SubStateMachineExporter extends StateMachineExporterBase {
 		subSmSpec.append(
 				StateMachineTemplates.exit(ownerClassName, createStateActionMap(entryExitFunctionExporter.getExitMap()))
 						+ "\n");
-
+		subSmSpec.append(StateMachineTemplates.finalizeFunctionDef(ownerClassName));
+		subSmSpec.append(StateMachineTemplates.initializeFunctionDef(ownerClassName, getInitialTransition(stateMachineRegion).getName()));
 		source.append(GenerationTemplates.formatSubSmFunctions(subSmSpec.toString()));
 
 		return source.toString();

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/structural/ConstructorExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/structural/ConstructorExporter.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.eclipse.uml2.uml.Operation;
 
+import hu.elte.txtuml.export.cpp.ActivityExportResult;
 import hu.elte.txtuml.export.cpp.CppExporterUtils;
 import hu.elte.txtuml.export.cpp.activity.ActivityExporter;
 import hu.elte.txtuml.export.cpp.templates.structual.ConstructorTemplates;
@@ -27,11 +28,11 @@ class ConstructorExporter {
 	String exportConstructorsDefinitions(String className, boolean ownStateMachine) {
 		StringBuilder source = new StringBuilder();
 		for (Operation operation : constructors) {
-			String body = activityExporter.createFunctionBody(CppExporterUtils.getOperationActivity(operation));
+			ActivityExportResult activityResult = activityExporter.createFunctionBody(CppExporterUtils.getOperationActivity(operation));
 			source.append(
 					ConstructorTemplates.constructorDef(className, CppExporterUtils.getOperationParamNames(operation),
 							CppExporterUtils.getOperationParams(operation)));
-			source.append(ConstructorTemplates.initDef(className, body, CppExporterUtils.getOperationParams(operation),
+			source.append(ConstructorTemplates.initDef(className, activityResult.getActivitySource(), CppExporterUtils.getOperationParams(operation),
 					ownStateMachine));
 
 		}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/structural/StructuredElementExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/structural/StructuredElementExporter.java
@@ -11,6 +11,7 @@ import org.eclipse.uml2.uml.Parameter;
 import org.eclipse.uml2.uml.Property;
 import org.eclipse.uml2.uml.VisibilityKind;
 
+import hu.elte.txtuml.export.cpp.ActivityExportResult;
 import hu.elte.txtuml.export.cpp.CppExporterUtils;
 import hu.elte.txtuml.export.cpp.activity.ActivityExporter;
 import hu.elte.txtuml.export.cpp.templates.structual.FunctionTemplates;
@@ -72,14 +73,14 @@ public abstract class StructuredElementExporter<StructuredElement extends Operat
 	protected String createOperationDefinitions() {
 		StringBuilder source = new StringBuilder("");
 		for (Operation operation : structuredElement.getOwnedOperations()) {
-			String funcBody = activityExporter.createFunctionBody(CppExporterUtils.getOperationActivity(operation));
+			ActivityExportResult activityResult = activityExporter.createFunctionBody(CppExporterUtils.getOperationActivity(operation));
 			dependencyExporter.addDependencies(activityExporter.getAdditionalClassDependencies());
 
 			if (!CppExporterUtils.isConstructor(operation)) {
 
 				String returnType = getReturnType(operation.getReturnResult());
 				source.append(FunctionTemplates.functionDef(name, returnType, operation.getName(),
-						CppExporterUtils.getOperationParams(operation), funcBody));
+						CppExporterUtils.getOperationParams(operation), activityResult.getActivitySource()));
 			}
 
 		}

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/GenerationNames.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/GenerationNames.java
@@ -93,6 +93,7 @@ public class GenerationNames {
 	public static class GeneralFunctionNames {
 		public static final String GeneralLinkFunction = "link";
 		public static final String GeneralUnlinkFunction = "unlink";
+		public static final String InitFunctionName = "init";
 	}
 
 	public static class Containers {
@@ -101,9 +102,22 @@ public class GenerationNames {
 
 	public static class StateMachineMethodNames {
 		public static final String DeleteStatemachine = "deleteSM";
-		public static final String InitFunctionName = "init";
 		public static final String ProcessEventFName = "process_event";
-		public static final String InitTansitionFunctionName = "Initialize";
+		public static final String InitializeFunctionName = "initialize";
+		public static final String FinalizeFunctionName = "finalize";
+	}
+	
+	public static class EntryExitNames {
+
+		public static final String EntryName = "entry";
+		public static final String ExitName = "exit";
+		public static final String EntryDecl = GenerationNames.ModifierNames.NoReturn + " " + EntryName + "("
+		+ EventTemplates.EventPointerType + " " + EventTemplates.EventFParamName + ");\n";
+		public static final String ExitDecl = GenerationNames.ModifierNames.NoReturn + " " + ExitName + "("
+		+ EventTemplates.EventPointerType + " " + EventTemplates.EventFParamName + ");\n";
+		public static final String EntryInvoke = EntryName + "(" + EventTemplates.EventFParamName + ");";
+		public static final String ExitInvoke = ExitName + "(" + EventTemplates.EventFParamName + ");";
+		
 	}
 
 	public static final String ClassType = "struct";
@@ -120,14 +134,6 @@ public class GenerationNames {
 	public static final String EventClassTypeId = "_EC";
 	public static final String EventEnumTypeId = "_EE";
 	public static final String StateEnumTypeId = "_ST";
-	public static final String EntryName = "entry";
-	public static final String ExitName = "exit";
-	public static final String EntryDecl = ModifierNames.NoReturn + " " + EntryName + "("
-			+ EventTemplates.EventPointerType + " " + EventTemplates.EventFParamName + ");\n";
-	public static final String ExitDecl = ModifierNames.NoReturn + " " + ExitName + "("
-			+ EventTemplates.EventPointerType + " " + EventTemplates.EventFParamName + ");\n";
-	public static final String EntryInvoke = EntryName + "(" + EventTemplates.EventFParamName + ");";
-	public static final String ExitInvoke = ExitName + "(" + EventTemplates.EventFParamName + ");";
 	public static final String StateParamName = "s_";
 	public static final String TransitionTableName = "_mM";
 	public static final String SetStateFuncName = "setState";
@@ -187,7 +193,7 @@ public class GenerationNames {
 			+ GenerationNames.ParentSmPointerName + ")";
 
 	public static String initFunctionName(String className) {
-		return StateMachineMethodNames.InitFunctionName + className;
+		return GeneralFunctionNames.InitFunctionName + className;
 	}
 
 	public static String friendClassDecl(String className) {
@@ -203,7 +209,6 @@ public class GenerationNames {
 				+ EventTemplates.EventFParamName + ")\n" + simpleProcessEventDefBody();
 	}
 
-	
 	public static String simpleProcessEventDef(String className) {
 		return "bool " + className + "::" + StateMachineMethodNames.ProcessEventFName + "("
 				+ EventTemplates.EventPointerType + " " + EventTemplates.EventFParamName + ")\n"
@@ -227,25 +232,30 @@ public class GenerationNames {
 				+ GenerationNames.PointerAndMemoryNames.PointerAccess + "getPortType()));\n" + "if(range.first!="
 				+ TransitionTableName + ".end())\n" + "{\n" + "for(auto it=range.first;it!=range.second;++it)\n" + "{\n"
 				+ "if((it->second).first(*this," + EventTemplates.EventFParamName + "))//Guard call\n" + "{\n"
-				+ ExitInvoke + "(it->second).second(*this," + EventTemplates.EventFParamName + ");//Action Call\n"
-				+ "handled=true;\n" + "break;\n" + "}\n" + "}\n" + "}\n" + "return handled;\n" + "}\n";
+				+ EntryExitNames.ExitInvoke + "(it->second).second(*this," + EventTemplates.EventFParamName + ");//Action Call\n"
+				+ EntryExitNames.EntryInvoke + "handled=true;\n" + "break;\n" + "}\n" + "}\n" + "}\n" + "return handled;\n" + "}\n";
+	}
+
+	private static final String setStateFunctionDefSharedHeaderPart(String className) {
+		return ModifierNames.NoReturn + " " + className + "::" + SetStateFuncName + "(int "
+				+ GenerationNames.StateParamName + ")";
+	}
+
+	private static final String setStateFunctionDefSharedStatementPart() {
+		return CurrentStateName + "=" + GenerationNames.StateParamName + ";";
 	}
 
 	public static String simpleSetStateDef(String className) {
-		return ModifierNames.NoReturn + " " + className + "::" + SetStateFuncName + "(int "
-				+ GenerationNames.StateParamName + "){" + CurrentStateName + "=" + GenerationNames.StateParamName
-				+ ";}\n";
+		return setStateFunctionDefSharedHeaderPart(className) + "{" + setStateFunctionDefSharedStatementPart() + "}\n";
 	}
 
 	public static String hierachicalSetStateDef(String className) {
-		return ModifierNames.NoReturn + " " + className + "::" + SetStateFuncName + "(int "
-				+ GenerationNames.StateParamName + ")\n" + "{\n" + "auto it=" + CompositeStateMapName + ".find("
-				+ GenerationNames.StateParamName + ");\n" + "if(it!=" + CompositeStateMapName + ".end())\n" + "{\n"
-				+ CurrentMachineName + "=(it->second).get();\n" + CurrentMachineName + "->" + SetInitialStateName
-				+ "();//restarting from initial state\n" + CurrentMachineName + "->"
-				+ StateMachineMethodNames.InitTansitionFunctionName + "(" + PointerAndMemoryNames.NullPtr + ");\n"
-				+ "}\n" + "else\n" + "{\n" + CurrentMachineName + "=" + PointerAndMemoryNames.NullPtr + ";\n" + "}\n"
-				+ CurrentStateName + "=" + GenerationNames.StateParamName + ";\n" + "}\n";
+		return setStateFunctionDefSharedHeaderPart(className) + "\n" + "{\n" + "auto it=" + CompositeStateMapName
+				+ ".find(" + GenerationNames.StateParamName + ");\n" + "if(it!=" + CompositeStateMapName + ".end())\n"
+				+ "{\n" + CurrentMachineName + "=(it->second).get();\n" + CurrentMachineName + "->"
+				+ SetInitialStateName + "();//restarting from initial state\n" + "}\n" + "else\n" + "{\n"
+				+ CurrentMachineName + "=" + PointerAndMemoryNames.NullPtr + ";\n" + "}\n" + CurrentStateName + "="
+				+ GenerationNames.StateParamName + ";\n" + "}\n";
 	}
 
 	public static String eventClassName(String eventName) {

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/RuntimeTemplates.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/RuntimeTemplates.java
@@ -65,7 +65,7 @@ public class RuntimeTemplates {
 		params.add(new Pair<String,String>(GenerationNames.PointerAndMemoryNames.EventPtr, eventName));
 		return FunctionTemplates.functionDef(className, 
 				StateMachineTemplates.ProcessInitTransitionFunctionName, 
-				params, StateMachineMethodNames.InitTansitionFunctionName + "(" + GenerationNames.formatIncomingParamName(eventName) + ");");
+				params, StateMachineMethodNames.InitializeFunctionName + "(" + GenerationNames.formatIncomingParamName(eventName) + ");");
 
 	}
 	

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/activity/ActivityTemplates.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/activity/ActivityTemplates.java
@@ -103,7 +103,7 @@ public class ActivityTemplates {
 	}
 
 	public static String operationCallOnPointerVariable(String ownerName, String operationName, List<String> params) {
-		return operationCall(ownerName, PointerAndMemoryNames.PointerAccess, operationName, params);
+		return blockStatement(operationCall(ownerName, PointerAndMemoryNames.PointerAccess, operationName, params));
 	}
 
 	public static String blockStatement(String statement) {
@@ -132,8 +132,8 @@ public class ActivityTemplates {
 			source.append(PointerAndMemoryNames.DeleteObject + " " + objectVariable + ";\n");
 
 		} else {
-			source.append(blockStatement(operationCallOnPointerVariable(objectVariable, 
-					GenerationNames.StateMachineMethodNames.DeleteStatemachine, Collections.emptyList())));
+			source.append(operationCallOnPointerVariable(objectVariable, 
+					GenerationNames.StateMachineMethodNames.DeleteStatemachine, Collections.emptyList()));
 		}
 		
 		return source.toString();

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/statemachine/EventTemplates.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/statemachine/EventTemplates.java
@@ -1,5 +1,6 @@
 package hu.elte.txtuml.export.cpp.templates.statemachine;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -23,6 +24,10 @@ public class EventTemplates {
 	public static final String EventBaseName = "EventBase";
 	public static final String EventsEnumName = "Events";
 	public static final String EventPointerType = GenerationNames.PointerAndMemoryNames.EventPtr;
+	
+	public static final List<String> EventParamVarList = Arrays.asList(EventFParamName);
+	public static final List<String> EventParamDeclList = Arrays.asList(EventPointerType);
+	public static final List<Pair<String,String>> EventParamDefList = Arrays.asList(new Pair<>(EventPointerType, EventParamName)); 
 
 	public static String eventClass(String className, List<Pair<String, String>> params, String constructorBody,
 			List<Property> properites) {

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/structual/HeaderTemplates.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/cpp/templates/structual/HeaderTemplates.java
@@ -45,7 +45,7 @@ public class HeaderTemplates {
 			String parentClass, String publicPart, String protectedPart, String privatePart, Boolean rt) {
 		return HeaderTemplates.classHeader(PrivateFunctionalTemplates.classHeaderIncludes(rt) + dependency, className,
 				baseClassName, StateMachineTemplates.stateMachineClassFixPublicParts(className, rt) + publicPart,
-				 protectedPart, StateMachineTemplates.simpleStateMachineClassFixPrivateParts(className) + privatePart,
+				 protectedPart, StateMachineTemplates.stateMachineClassFixPrivateParts(className) + privatePart,
 				true, rt);
 	}
 

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/fmu/EnvironmentExporter.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/fmu/EnvironmentExporter.java
@@ -76,6 +76,8 @@ public class EnvironmentExporter {
 		while (matcher.find()) {
 			if (matcher.group().equals("$fmuclass")) {
 				matcher.appendReplacement(sb, unqualify(fmuConfig.umlClassName));
+			} else if (matcher.group().equals("$fmuassociationend")) {
+				matcher.appendReplacement(sb, fmuConfig.fmuAssociationEndName);
 			}
 		}
 		matcher.appendTail(sb);

--- a/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/fmu/FMUConfig.java
+++ b/dev/plugins/hu.elte.txtuml.export.cpp/src/hu/elte/txtuml/export/fmu/FMUConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 public class FMUConfig {
 
 	String umlClassName;
+	String fmuAssociationEndName;
 	Optional<String> outputSignalConfig;
 	List<VariableDefinition> outputVariables;
 	

--- a/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/.classpath
+++ b/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="src-gen"/>
 	<classpathentry kind="con" path="hu.elte.txtuml.project.runtimeClasspathInitializer"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/SinkFMIConfiguration.java
+++ b/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/SinkFMIConfiguration.java
@@ -2,14 +2,17 @@ package hu.elte.txtuml.examples.feeder;
 
 import hu.elte.txtuml.api.deployment.fmi.FMIConfiguration;
 import hu.elte.txtuml.api.deployment.fmi.FMU;
+import hu.elte.txtuml.api.deployment.fmi.FMUAssociationEnd;
 import hu.elte.txtuml.api.deployment.fmi.FMUInput;
 import hu.elte.txtuml.api.deployment.fmi.FMUOutput;
 import hu.elte.txtuml.api.deployment.fmi.InitialRealValue;
 import hu.elte.txtuml.examples.feeder.model.RequestSignal;
 import hu.elte.txtuml.examples.feeder.model.ResponseSignal;
 import hu.elte.txtuml.examples.feeder.model.Sink;
+import hu.elte.txtuml.examples.feeder.model.SinkSourceAssoc;
 
 @FMU(fmuClass = Sink.class)
+@FMUAssociationEnd(fmuAssociationEnd = SinkSourceAssoc.sink.class)
 @FMUInput(inputSignal = ResponseSignal.class)
 @FMUOutput(outputSignal = RequestSignal.class)
 @InitialRealValue(variableName = "data", value = 0)

--- a/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/SourceFMIConfiguration.java
+++ b/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/SourceFMIConfiguration.java
@@ -2,14 +2,17 @@ package hu.elte.txtuml.examples.feeder;
 
 import hu.elte.txtuml.api.deployment.fmi.FMIConfiguration;
 import hu.elte.txtuml.api.deployment.fmi.FMU;
+import hu.elte.txtuml.api.deployment.fmi.FMUAssociationEnd;
 import hu.elte.txtuml.api.deployment.fmi.FMUInput;
 import hu.elte.txtuml.api.deployment.fmi.FMUOutput;
 import hu.elte.txtuml.api.deployment.fmi.InitialIntegerValue;
 import hu.elte.txtuml.examples.feeder.model.RequestSignal;
 import hu.elte.txtuml.examples.feeder.model.ResponseSignal;
+import hu.elte.txtuml.examples.feeder.model.SinkSourceAssoc;
 import hu.elte.txtuml.examples.feeder.model.Source;
 
 @FMU(fmuClass = Source.class)
+@FMUAssociationEnd(fmuAssociationEnd = SinkSourceAssoc.source.class)
 @FMUInput(inputSignal = RequestSignal.class)
 @FMUOutput(outputSignal = ResponseSignal.class)
 @InitialIntegerValue(variableName = "amount", value = 0)

--- a/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/model/SinkSourceAssoc.java
+++ b/examples/tests/Feeder/hu.elte.txtuml.examples.feeder/src/hu/elte/txtuml/examples/feeder/model/SinkSourceAssoc.java
@@ -5,10 +5,10 @@ import hu.elte.txtuml.api.model.ModelClass;
 
 public class SinkSourceAssoc extends Association {
 
-	class sink extends One<ModelClass> {
+	public class sink extends One<ModelClass> {
 	}
 
-	class source extends One<ModelClass> {
+	public class source extends One<ModelClass> {
 	}
 
 }

--- a/examples/tests/MoonLander/MoonLander/src/hu/eltesoft/moonlander/MoonLanderFMIConfiguration.java
+++ b/examples/tests/MoonLander/MoonLander/src/hu/eltesoft/moonlander/MoonLanderFMIConfiguration.java
@@ -2,14 +2,17 @@ package hu.eltesoft.moonlander;
 
 import hu.elte.txtuml.api.deployment.fmi.FMIConfiguration;
 import hu.elte.txtuml.api.deployment.fmi.FMU;
+import hu.elte.txtuml.api.deployment.fmi.FMUAssociationEnd;
 import hu.elte.txtuml.api.deployment.fmi.FMUInput;
 import hu.elte.txtuml.api.deployment.fmi.FMUOutput;
 import hu.elte.txtuml.api.deployment.fmi.InitialRealValue;
 import hu.eltesoft.moonlander.model.InputSignal;
-import hu.eltesoft.moonlander.model.OutputSignal;
+import hu.eltesoft.moonlander.model.LanderWorld;
 import hu.eltesoft.moonlander.model.MoonLander;
+import hu.eltesoft.moonlander.model.OutputSignal;
 
 @FMU(fmuClass = MoonLander.class)
+@FMUAssociationEnd(fmuAssociationEnd = LanderWorld.lander.class)
 @FMUInput(inputSignal = InputSignal.class)
 @FMUOutput(outputSignal = OutputSignal.class)
 @InitialRealValue(variableName = "h", value = 0)


### PR DESCRIPTION
In the current implementation, for each FMU class an association has to be defined between the class and the FMU environment. As the latter is a special entity, we generate its C++ implementation separately. Due to the aforementioned association – and by the design of the C++ runtime –, we have to include the association end of the FMU class as an attribute in the generated C++ code of the FMU environment.

Previously, the name of this association end was fixed to `LanderWorld.lander`. This pull request makes it configurable with the `@FMUAssociationEnd` annotation, and also incorporates critical fixes of #529. For additional details, see the (full) commit messages.