### PR TITLE
Guard expression code export

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -21,6 +21,7 @@ import org.eclipse.jdt.core.dom.InfixExpression
 import org.eclipse.jdt.core.dom.SimpleName
 import org.eclipse.jdt.core.dom.PrefixExpression
 import org.eclipse.jdt.core.dom.MethodInvocation
+import org.eclipse.jdt.core.dom.ParenthesizedExpression
 
 class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constraint> {
 	
@@ -90,7 +91,10 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		var resultExpr = expr
 		if(resultExpr instanceof SimpleName && varCodes.containsKey((resultExpr as SimpleName).identifier)) {
 			resultExpr = updateExpression(varCodes.get((resultExpr as SimpleName).identifier), varCodes)
-		} else if(resultExpr instanceof InfixExpression) {
+		} else if(resultExpr instanceof ParenthesizedExpression) {
+			resultExpr = updateExpression(resultExpr.expression,varCodes)
+		}
+		else if(resultExpr instanceof InfixExpression) {
 			val updatedLeft =  updateExpression(resultExpr.leftOperand, varCodes)
 			val updadtedRight = updateExpression(resultExpr.rightOperand, varCodes)
 			if(updatedLeft?.parent != resultExpr) { 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -154,17 +154,21 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 	
 	def String asString(Expression expr) {
 		if(expr instanceof InfixExpression) {
+			
 			val leftCode = asString(expr.leftOperand)
 			val rigthCode = asString(expr.rightOperand)
 			
 			return leftCode + expr.operator + rigthCode
 		} if(expr instanceof ParenthesizedExpression) {
+			
 			return asString(expr.expression)
 			
 		} else if(expr instanceof PrefixExpression) {
+			
 			return expr.operator + 	asString(expr.operand)	 
 			 
 		} else if(expr instanceof MethodInvocation) {
+			
 			val invName = expr.resolveMethodBinding.name
 			if(invName == "getTrigger") {
 				return "trigger"
@@ -173,13 +177,7 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 			}
 			
 			val targetExpr = expr.expression
-			var targetCode = ""
-			if(targetExpr != null) {
-				targetCode = asString(targetExpr)
-				if(!targetCode.empty) {
-					targetCode += "."
-				}
-			}
+			var targetCode = targetExpressionAsString(targetExpr)
 			
 			var operationCode = expr.name.identifier
 			var paramCodes = ""
@@ -194,18 +192,13 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 			
 			return targetCode + operationCode
 						
-		} else if(expr instanceof ThisExpression) {
-			return ""
+		} else if(expr instanceof ThisExpression) {	
+				
+			return "this"
+						
 		} else if(expr instanceof FieldAccess) {
-			val targetExpr = expr.expression
-			var targetCode = ""
-			if(targetExpr != null) {
-				targetCode = asString(targetExpr)
-				if(!targetCode.empty) {
-					targetCode += "."
-				}
-			}
 			
+			var targetCode = targetExpressionAsString(expr.expression)			
 			return targetCode + expr.name.identifier
 		}
 		
@@ -213,7 +206,20 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		expr.toString
 	}
 
-	
+	def String targetExpressionAsString(Expression target) {
+		var targetCode = ""
+		if(target != null) {
+			if(!(target instanceof ThisExpression)) {
+				targetCode = asString(target)
+			}
+			if(!targetCode.empty) {
+				targetCode += "."
+			}
+
+		}
+		
+		targetCode
+	}
 	
 	def StateMachine getSM(Region reg) { reg.stateMachine ?: reg.state.container.getSM() }
 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -156,11 +156,11 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 				val leftCode = asString(expr.leftOperand)
 				val rightCode = asString(expr.rightOperand)
 
-				return leftCode + expr.operator + rightCode
+				return leftCode + " " + expr.operator + " " + rightCode
 			}
 
 			ParenthesizedExpression: {
-				return asString(expr.expression)
+				return "(" + asString(expr.expression) + ")"
 			}
 
 			PrefixExpression: {
@@ -172,7 +172,7 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 				if (invName == "getTrigger") {
 					return "trigger"
 				} else if (invName == "Else") {
-					return "else()";
+					return "else";
 				}
 
 				val targetExpr = expr.expression
@@ -181,10 +181,10 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 				var operationCode = expr.name.identifier
 				var paramCodes = ""
 				for (param : expr.arguments) {
-					paramCodes += asString(param as Expression) + ","
+					paramCodes += asString(param as Expression) + ", "
 				}
 				if (!paramCodes.empty) {
-					paramCodes = paramCodes.substring(0, paramCodes.length - 1)
+					paramCodes = paramCodes.substring(0, paramCodes.length - 2)
 				}
 
 				operationCode += "(" + paramCodes + ")"

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -78,14 +78,9 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 					}
 				}
 		]
-		
-		for(Object statement : blockStatements) {	
-			if(statement instanceof ReturnStatement) { 
-				guardExpressionSource = updateExpression(statement.expression, localVariables).toString
-				
-
-			}
-		}
+		val retExpr = blockStatements.findFirst[it instanceof ReturnStatement] as ReturnStatement
+		guardExpressionSource = updateExpression(retExpr.expression, localVariables).toString
+			
 		
 		return guardExpressionSource
 	}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -8,6 +8,12 @@ import org.eclipse.uml2.uml.Constraint
 import org.eclipse.uml2.uml.Transition
 import org.eclipse.uml2.uml.Region
 import org.eclipse.uml2.uml.StateMachine
+import org.eclipse.jdt.core.dom.Block
+import java.util.HashMap
+import java.util.Map
+import org.eclipse.jdt.core.dom.Assignment
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment
 
 class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constraint> {
 
@@ -21,9 +27,41 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		val opaqueExpr = factory.createOpaqueExpression
 		result.specification = opaqueExpr
 		result.name = "guard_specification"
-		opaqueExpr.behavior = exportSMActivity(source) [
+		if(exportActions) {
+			opaqueExpr.behavior = exportSMActivity(source) [
 			(result.owner as Transition).container.getSM.ownedBehaviors += it
-		]
+			]
+		}
+
+		opaqueExpr.languages += "JAVA"
+		opaqueExpr.bodies += createFaltGuardExpressionCode(source.body)
+	}
+	//TODO create guard code
+	def String createFaltGuardExpressionCode(Block block) {
+		/*val resCode = ""
+		val varCodes = new HashMap<String,String>()
+		val blockStatements = block.statements
+		for(Object statement : blockStatements) {
+			if(statement instanceof VariableDeclarationStatement) {
+				val varDecl = statement as VariableDeclarationStatement;
+				varDecl.fragments.forEach[
+					val decl = it as VariableDeclarationFragment
+					varCodes.put(decl.name.identifier, "")
+				]
+			}
+			
+		}
+		
+		for(Object statement : blockStatements) {
+			if(statement instanceof Assignment) {
+				val varDecl = statement as Assignment;
+				val expr
+			}
+			
+		}
+				
+		
+		resCode*/
 	}
 	
 	def StateMachine getSM(Region reg) { reg.stateMachine ?: reg.state.container.getSM() }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -50,7 +50,7 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		val localVariables = new HashMap<String,Expression>()
 		val blockStatements = block.statements
 		
-		var guardExpressionSource = "error"
+		var guardExpressionSource = "?"
 		var c = blockStatements.stream.filter[s | !(s instanceof VariableDeclarationStatement) && 
 			 !(s instanceof Assignment) && 
 			 !(s instanceof ReturnStatement)].count	

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -92,15 +92,15 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		} else if(resultExpr instanceof InfixExpression) {
 			val updatedLeft =  updateExpression(resultExpr.leftOperand, varCodes)
 			val updadtedRight = updateExpression(resultExpr.rightOperand, varCodes)
-			if(tryDelete(updatedLeft)) resultExpr.leftOperand = updatedLeft
-			if(tryDelete(updadtedRight)) tryDelete(updadtedRight) resultExpr.rightOperand = updadtedRight
+			if(updatedLeft?.parent != resultExpr) resultExpr.leftOperand = updatedLeft
+			if(updadtedRight?.parent != resultExpr) resultExpr.rightOperand = updadtedRight
 		} else if(resultExpr instanceof PrefixExpression) {
 			val updatedExpr = updateExpression(resultExpr.operand, varCodes)		
-			if(tryDelete(updatedExpr)) resultExpr.operand = updatedExpr			 
+			if(updatedExpr?.parent != resultExpr) resultExpr.operand = updatedExpr			 
 			 
 		} else if(resultExpr instanceof MethodInvocation) {
 			val updatedExpr = updateExpression(resultExpr.expression, varCodes)
-			if(tryDelete(updatedExpr)) resultExpr.expression = updatedExpr
+			if(updatedExpr?.parent != resultExpr) resultExpr.expression = updatedExpr
 			var updatedArguments = new LinkedList<Object> 
 			for(Object e : resultExpr.arguments) {
 				val updatedArgument = updateExpression(e as Expression,varCodes)
@@ -119,16 +119,7 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		
 		
 	}
-	
-	
-	def boolean tryDelete(Expression expr) {
-		try {
-				expr?.delete
-				 true
-		} catch(Exception e) {
-				false
-		}
-	}
+
 	
 	
 	def StateMachine getSM(Region reg) { reg.stateMachine ?: reg.state.container.getSM() }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -85,7 +85,6 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		for(Object statement : blockStatements) {	
 			if(statement instanceof ReturnStatement) { 
 				guardExpression = statement.expression
-				//TODO update does not work properly, invalid child and parent..
 				guardExpression = updateExpression(guardExpression, localVariables)
 
 			}
@@ -96,11 +95,14 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 	
 	def Expression updateExpression(Expression expr, Map<String,Expression> varCodes) {
 		var resultExpr = expr
+		//TODO consider more possible expression type
 		if(resultExpr instanceof SimpleName && varCodes.containsKey((resultExpr as SimpleName).identifier)) {
-			resultExpr = varCodes.get((resultExpr as SimpleName).identifier)
+			resultExpr = updateExpression(varCodes.get((resultExpr as SimpleName).identifier), varCodes)
 		} else if(resultExpr instanceof  InfixExpression) {
 			val updatedLeft =  updateExpression(resultExpr.leftOperand, varCodes)
 			val updadtedRigthright = updateExpression(resultExpr.rightOperand, varCodes)
+			updatedLeft.delete
+			updadtedRigthright.delete
 			resultExpr.leftOperand = updatedLeft
 			resultExpr.rightOperand = updadtedRigthright
 		}

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -97,9 +97,12 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 			SimpleName case varCodes.containsKey(resultExpr.identifier):
 				return updateExpression(varCodes.get(resultExpr.identifier), varCodes)
 
-			ParenthesizedExpression:
-				return updateExpression(resultExpr.expression, varCodes)
-
+			ParenthesizedExpression: {
+				val updatedChild = updateExpression(resultExpr.expression, varCodes)
+				if(updatedChild?.parent != resultExpr) {
+					resultExpr.expression = updatedChild
+				}
+			}
 			InfixExpression: {
 				val updatedLeft = updateExpression(resultExpr.leftOperand, varCodes)
 				val updatedRight = updateExpression(resultExpr.rightOperand, varCodes)

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/GuardExporter.xtend
@@ -10,19 +10,25 @@ import org.eclipse.uml2.uml.Region
 import org.eclipse.uml2.uml.StateMachine
 import org.eclipse.jdt.core.dom.Block
 import java.util.HashMap
-import java.util.Map
 import org.eclipse.jdt.core.dom.Assignment
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment
+import org.eclipse.jdt.core.dom.Name
+import hu.elte.txtuml.utils.jdt.ElementTypeTeller
+import org.eclipse.jdt.core.dom.ReturnStatement
+import java.util.Map
+import java.util.Set
 
 class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constraint> {
-
+	
+	private String guardCode
+	
 	new(BaseExporter<?, ?, ?> parent) {
 		super(parent)
 	}
 
 	override create(IMethodBinding access) { factory.createConstraint }
-
+	
 	override exportContents(MethodDeclaration source) {
 		val opaqueExpr = factory.createOpaqueExpression
 		result.specification = opaqueExpr
@@ -34,34 +40,82 @@ class GuardExporter extends Exporter<MethodDeclaration, IMethodBinding, Constrai
 		}
 
 		opaqueExpr.languages += "JAVA"
-		opaqueExpr.bodies += createFaltGuardExpressionCode(source.body)
+		guardCode = ""
+		createFaltGuardExpressionCode(source.body)
+		opaqueExpr.bodies += guardCode
 	}
-	//TODO create guard code
-	def String createFaltGuardExpressionCode(Block block) {
-		/*val resCode = ""
-		val varCodes = new HashMap<String,String>()
+	
+	// TODO need a more elegant solution..
+	def void createFaltGuardExpressionCode(Block block) {
+		
+		val localVariables = new HashMap<String,String>()
 		val blockStatements = block.statements
 		for(Object statement : blockStatements) {
 			if(statement instanceof VariableDeclarationStatement) {
 				val varDecl = statement as VariableDeclarationStatement;
 				varDecl.fragments.forEach[
 					val decl = it as VariableDeclarationFragment
-					varCodes.put(decl.name.identifier, "")
+					localVariables.put(decl.name.identifier, "")
 				]
 			}
 			
 		}
 		
 		for(Object statement : blockStatements) {
+			
 			if(statement instanceof Assignment) {
-				val varDecl = statement as Assignment;
-				val expr
+				
+				val assignment = statement as Assignment;
+				val leftExpr = assignment.leftHandSide
+				val rigthExpr = assignment.rightHandSide
+				
+				if(leftExpr instanceof Name && ElementTypeTeller.isVariable(leftExpr)) {
+					val leftVarName = (leftExpr as Name).resolveBinding.name;
+					if(localVariables.containsKey(leftVarName)) {
+						localVariables.put(leftVarName, rigthExpr.toString)
+					}
+				}
 			}
 			
 		}
-				
 		
-		resCode*/
+		
+		for(Object statement : blockStatements) {	
+			if(statement instanceof ReturnStatement) { 
+				guardCode = statement.toString
+				resolveExpressionCode(localVariables)
+			}
+		}
+		
+	}
+	
+	def void resolveExpressionCode(Map<String,String> varCodes) {
+		val varNames = varCodes.keySet
+		while(containsAnyOfThem(guardCode, varNames)) {
+			guardCode = replaceToVarExpressions(guardCode, varCodes)
+		}
+		
+	}
+	
+	def boolean containsAnyOfThem(String code, Set<String> strings) {
+		for(String  varName : strings) {
+			if(code.contains(varName)) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	def String replaceToVarExpressions(String code, Map<String,String> varCodes) {
+		val res = code
+		for(String varName : varCodes.keySet) {
+			if(code.contains(varName)) {
+				res.replace(varName, varCodes.get(varName))
+			}
+		}
+		
+		res
 	}
 	
 	def StateMachine getSM(Region reg) { reg.stateMachine ?: reg.state.container.getSM() }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/TransitionExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/statemachine/TransitionExporter.xtend
@@ -41,9 +41,10 @@ class TransitionExporter extends Exporter<TypeDeclaration, ITypeBinding, Transit
 				(it as MethodDeclaration).name.identifier == "effect"
 			].forEach[exportSMActivity(it as MethodDeclaration)[result.effect = it]]
 
-			source.bodyDeclarations.filter[it instanceof MethodDeclaration].map[it as MethodDeclaration].filter [
+		}
+		
+		source.bodyDeclarations.filter[it instanceof MethodDeclaration].map[it as MethodDeclaration].filter [
 				name.identifier == "guard"
 			].forEach[exportGuard[result.guard = it]]
-		}
 	}
 }


### PR DESCRIPTION
I hope is resolves #547.

Supported guard activites: The guard blocks can contain only assigments, variable declerations and  return statements. The return expression can be arbitrary complicated. 