### PR TITLE
Fix layout export of compositions

### DIFF
--- a/dev/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/utils/Associations.java
+++ b/dev/plugins/hu.elte.txtuml.api.model/src/hu/elte/txtuml/api/model/utils/Associations.java
@@ -4,6 +4,7 @@ import java.lang.reflect.ParameterizedType;
 
 import hu.elte.txtuml.api.model.AssociationEnd;
 import hu.elte.txtuml.api.model.AssociationEnd.Container;
+import hu.elte.txtuml.api.model.GeneralCollection;
 import hu.elte.txtuml.api.model.ZeroToOne;
 
 /**
@@ -44,8 +45,41 @@ public final class Associations {
 
 	@SuppressWarnings("unchecked")
 	public static <C> Class<C> getCollectionTypeOfNonContainerEnd(Class<? extends AssociationEnd<C>> assocEndType) {
-		return (Class<C>) ((ParameterizedType) ((ParameterizedType) assocEndType.getGenericSuperclass())
-				.getActualTypeArguments()[0]).getRawType();
+		ParameterizedType endType = (ParameterizedType) assocEndType.getGenericSuperclass();
+		ParameterizedType collectionType = (ParameterizedType) endType.getActualTypeArguments()[0];
+
+		return (Class<C>) collectionType.getRawType();
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T, C extends GeneralCollection<T>> Class<T> getElementTypeOf(AssociationEnd<C> assocEnd) {
+		return getElementTypeOf((Class<? extends AssociationEnd<C>>) assocEnd.getClass());
+	}
+
+	public static <T, C extends GeneralCollection<T>> Class<T> getElementTypeOf(
+			Class<? extends AssociationEnd<C>> assocEndType) {
+		if (Container.class.isAssignableFrom(assocEndType)) {
+			return getElementTypeOfContainerEnd(assocEndType);
+		} else {
+			return getElementTypeOfNonContainerEnd(assocEndType);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T, C extends GeneralCollection<T>> Class<T> getElementTypeOfContainerEnd(
+			Class<? extends AssociationEnd<C>> assocEndType) {
+		ParameterizedType endType = (ParameterizedType) assocEndType.getGenericSuperclass();
+
+		return (Class<T>) endType.getActualTypeArguments()[0];
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T, C extends GeneralCollection<T>> Class<T> getElementTypeOfNonContainerEnd(
+			Class<? extends AssociationEnd<C>> assocEndType) {
+		ParameterizedType endType = (ParameterizedType) assocEndType.getGenericSuperclass();
+		ParameterizedType collectionType = (ParameterizedType) endType.getActualTypeArguments()[0];
+
+		return (Class<T>) collectionType.getActualTypeArguments()[0];
 	}
 
 }

--- a/dev/plugins/hu.elte.txtuml.layout.export/src/hu/elte/txtuml/layout/export/source/ClassDiagramExporter.java
+++ b/dev/plugins/hu.elte.txtuml.layout.export/src/hu/elte/txtuml/layout/export/source/ClassDiagramExporter.java
@@ -1,7 +1,6 @@
 package hu.elte.txtuml.layout.export.source;
 
 import java.io.IOException;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -18,7 +17,9 @@ import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 import hu.elte.txtuml.api.model.Association;
 import hu.elte.txtuml.api.model.AssociationEnd;
+import hu.elte.txtuml.api.model.GeneralCollection;
 import hu.elte.txtuml.api.model.ModelClass;
+import hu.elte.txtuml.api.model.utils.Associations;
 import hu.elte.txtuml.layout.export.DiagramType;
 import hu.elte.txtuml.layout.export.interfaces.ElementExporter;
 import hu.elte.txtuml.layout.export.interfaces.NodeMap;
@@ -118,7 +119,8 @@ public class ClassDiagramExporter extends AbstractSourceExporter {
 		}
 
 		Class<?> base = node.getSuperclass();
-		if (base != null && allNodes.containsKey(base)) { // Load generalization.
+		if (base != null && allNodes.containsKey(base)) { // Load
+															// generalization.
 			try {
 				elementExporter.exportGeneralization(base, node);
 			} catch (ElementExportationException e) {
@@ -132,10 +134,9 @@ public class ClassDiagramExporter extends AbstractSourceExporter {
 		if (!AssociationEnd.class.isAssignableFrom(end)) {
 			return null;
 		}
+
 		try {
-			ParameterizedType endType = (ParameterizedType) end.getGenericSuperclass();
-			ParameterizedType collectionType = (ParameterizedType) endType.getActualTypeArguments()[0];
-			return (Class<? extends ModelClass>) collectionType.getActualTypeArguments()[0];
+			return Associations.getElementTypeOf((Class<? extends AssociationEnd<? extends GeneralCollection<?>>>) end);
 		} catch (Exception e) {
 			throw new ElementExportationException();
 		}

--- a/dev/plugins/hu.elte.txtuml.layout.export/src/hu/elte/txtuml/layout/export/source/ClassDiagramExporter.java
+++ b/dev/plugins/hu.elte.txtuml.layout.export/src/hu/elte/txtuml/layout/export/source/ClassDiagramExporter.java
@@ -119,8 +119,7 @@ public class ClassDiagramExporter extends AbstractSourceExporter {
 		}
 
 		Class<?> base = node.getSuperclass();
-		if (base != null && allNodes.containsKey(base)) { // Load
-															// generalization.
+		if (base != null && allNodes.containsKey(base)) { // Load generalization.
 			try {
 				elementExporter.exportGeneralization(base, node);
 			} catch (ElementExportationException e) {


### PR DESCRIPTION
Commit 9f33279dc67f40637a07a8b0053270a09d42e21b fixed the layout export
of implied associations but since the new collection framework, the simple
associations and the compositions must be handled differently and therefore
the compositions were still not exported after the above commit.