### PR TITLE
Fix sub package export when it is duplacted in src-gen

### DIFF
--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/BaseExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/BaseExporter.xtend
@@ -52,7 +52,7 @@ import org.eclipse.uml2.uml.Reception
 import hu.elte.txtuml.export.uml2.structural.ReceptionExporter
 import hu.elte.txtuml.export.uml2.structural.ConnectorTypeEndExporter
 import hu.elte.txtuml.export.uml2.structural.ConnectorTypeExporter
-import hu.elte.txtuml.export.uml2.structural.PortProvidedInfExporter
+import java.util.List
 
 /**
  * Base class for exporters, methods to export different kinds of elements using specific exporters.
@@ -75,7 +75,7 @@ abstract class BaseExporter<S, A, R extends Element> {
 
 	abstract def Element getImportedElement(String name)
 
-	def exportPackage(IPackageFragment pf, Consumer<Package> store) {
+	def exportPackage(List<IPackageFragment> pf, Consumer<Package> store) {
 		cache.export(new PackageExporter(this), pf, pf, store)
 	}
 

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/ModelExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/ModelExporter.xtend
@@ -85,7 +85,8 @@ class ModelExporter extends AbstractPackageExporter<List<IPackageFragment>, Mode
 		addPackageImport(STDPROF_URI)
 		addProfileApplication(getImportedElement(STD_PROF_NAME) as Profile)
 		result.importedMembers.forEach[importCache.put(it.name, it)]
-		rootFragments.forEach[super.exportPackageFragment(it)]
+		exportPackageFragment(rootFragments)
+		//rootFragments.forEach[super.exportPackageFragment(it)]
 	}
 
 	def setupResourceSet(IJavaProject project, String packageName) {

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
@@ -6,6 +6,7 @@ import hu.elte.txtuml.export.uml2.Exporter
 import hu.elte.txtuml.utils.jdt.ElementTypeTeller
 import hu.elte.txtuml.utils.jdt.SharedUtils
 import java.io.File
+import java.util.List
 import java.util.regex.Pattern
 import org.eclipse.jdt.core.ICompilationUnit
 import org.eclipse.jdt.core.IPackageFragment
@@ -15,8 +16,6 @@ import org.eclipse.jdt.core.dom.TypeDeclaration
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.PackageableElement
-import java.util.List
-import java.util.Collections
 
 abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S, S, T> {
 
@@ -29,47 +28,46 @@ abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S,
 	}
 
 	def exportPackageFragment(List<IPackageFragment> packageFragments) {
-		if(packageFragments.empty) {
+		if (packageFragments.empty) {
 			return
 		}
-			
-		packageFragments.forEach[packageFragment | 
+
+		packageFragments.forEach [ packageFragment |
 			packageFragment.children.forEach[exportCompUnit(it as ICompilationUnit)]
 		]
-		
-		if(packageFragments.size == 1) {
+
+		if (packageFragments.size == 1) {
 			val packageFregement = packageFragments.head
 			val subPackages = getSubPackages(packageFregement)
-			subPackages.forEach[p | exportPackage(#[p])[result.nestedPackages += it]]
-				
-		} else if(packageFragments.size == 2) {
+			subPackages.forEach[p|exportPackage(#[p])[result.nestedPackages += it]]
+
+		} else if (packageFragments.size == 2) {
 			val subPackages1 = getSubPackages(packageFragments.get(0))
 			val subPackages2 = getSubPackages(packageFragments.get(1))
-			Collections.sort(subPackages1, [p1, p2 | p1.elementName.compareTo(p2.elementName)])
-			Collections.sort(subPackages2, [p1, p2 | p1.elementName.compareTo(p2.elementName)])	
-				
-							
+
+			val compareNames = [ IPackageFragment pf1, IPackageFragment pf2 |
+				pf1.elementName.compareTo(pf2.elementName)
+			]
+			subPackages1.sort(compareNames)
+			subPackages2.sort(compareNames)
+
 			var i = 0
-			var j = 0			
-			while(i < subPackages1.size || j < subPackages2.size) {
-				
-				if(j >= subPackages2.size || 
-					(i < subPackages1.size && subPackages1.get(i).elementName < subPackages2.get(j).elementName)
-				) {
+			var j = 0
+			while (i < subPackages1.size || j < subPackages2.size) {
+				if (j >= subPackages2.size ||
+					(i < subPackages1.size && subPackages1.get(i).elementName < subPackages2.get(j).elementName)) {
 					val packageFragment1 = subPackages1.get(i)
 					exportPackage(#[packageFragment1])[result.nestedPackages += it]
 					i++
-				}
-				else if(i >= subPackages1.size || 
-					(j < subPackages2.size && subPackages1.get(i).elementName > subPackages2.get(j).elementName)
-				) {
+
+				} else if (i >= subPackages1.size ||
+					(j < subPackages2.size && subPackages1.get(i).elementName > subPackages2.get(j).elementName)) {
 					val packageFragment2 = subPackages2.get(j)
 					exportPackage(#[packageFragment2])[result.nestedPackages += it]
 					j++
-					
-				} else if(i < subPackages1.size && j < subPackages2.size && 
-					subPackages1.get(i).elementName == subPackages2.get(j).elementName
-				) {
+
+				} else if (i < subPackages1.size && j < subPackages2.size &&
+					subPackages1.get(i).elementName == subPackages2.get(j).elementName) {
 					val packageFragment1 = subPackages1.get(i)
 					val packageFragment2 = subPackages2.get(j)
 					exportPackage(#[packageFragment1, packageFragment2])[result.nestedPackages += it]
@@ -78,20 +76,18 @@ abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S,
 				}
 			}
 		}
-
-		
 	}
-	
+
 	def List<IPackageFragment> getSubPackages(IPackageFragment packageFregement) {
-			val packageRoot = packageFregement.parent as IPackageFragmentRoot
-			val subPackages = packageRoot.children.map[it as IPackageFragment].filter [
-					elementName.startsWith(packageFregement.elementName + ".")
-			]
-			subPackages.toList
+		val packageRoot = packageFregement.parent as IPackageFragmentRoot
+		val subPackages = packageRoot.children.map[it as IPackageFragment].filter [
+			elementName.startsWith(packageFregement.elementName + ".")
+		]
+		subPackages.toList
 	}
 
 	def exportCompUnit(ICompilationUnit compUnit) {
-		parseCompUnit(compUnit).types.filter[t | !ElementTypeTeller.isExternal(t as TypeDeclaration)].forEach[exportType]
+		parseCompUnit(compUnit).types.filter[t|!ElementTypeTeller.isExternal(t as TypeDeclaration)].forEach[exportType]
 	}
 
 	override storePackaged(PackageableElement pkg) {
@@ -133,7 +129,7 @@ abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S,
 				exportInterface(decl)[result.packagedElements += it]
 			}
 			case ElementTypeTeller.isCollection(decl): {
-				//TODO handle collection types
+				// TODO handle collection types
 			}
 			default:
 				throw new IllegalArgumentException("Illegal type declaration: " + decl.toString)

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
@@ -37,9 +37,9 @@ abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S,
 		]
 		
 		if(packageFragments.size == 1) {
-			val packageFregement = packageFragments.get(0)
-				val subPackages = getSubPackages(packageFregement)
-				subPackages.forEach[p | exportPackage(#[p])[result.nestedPackages += it]]
+			val packageFregement = packageFragments.head
+			val subPackages = getSubPackages(packageFregement)
+			subPackages.forEach[p | exportPackage(#[p])[result.nestedPackages += it]]
 				
 		} else if(packageFragments.size == 2) {
 			val subPackages1 = getSubPackages(packageFragments.get(0))
@@ -154,7 +154,7 @@ class PackageExporter extends AbstractPackageExporter<List<IPackageFragment>, Pa
 	override create(List<IPackageFragment> pf) { if(!pf.empty) factory.createPackage }
 
 	override exportContents(List<IPackageFragment> s) {
-		result.name = s.get(0).elementName.split(Pattern.quote(".")).last
+		result.name = s.head.elementName.split(Pattern.quote(".")).last
 		exportPackageFragment(s)
 	}
 }

--- a/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
+++ b/dev/plugins/hu.elte.txtuml.export.uml2/src/hu/elte/txtuml/export/uml2/structural/PackageExporter.xtend
@@ -16,6 +16,7 @@ import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.PackageableElement
 import java.util.List
+import java.util.Collections
 
 abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S, S, T> {
 
@@ -43,7 +44,10 @@ abstract class AbstractPackageExporter<S, T extends Package> extends Exporter<S,
 				
 		} else if(packageFragments.size == 2) {
 			val subPackages1 = getSubPackages(packageFragments.get(0))
-			val subPackages2 = getSubPackages(packageFragments.get(1))	
+			val subPackages2 = getSubPackages(packageFragments.get(1))
+			Collections.sort(subPackages1, [p1, p2 | p1.elementName.compareTo(p2.elementName)])
+			Collections.sort(subPackages2, [p1, p2 | p1.elementName.compareTo(p2.elementName)])	
+				
 							
 			var i = 0
 			var j = 0			


### PR DESCRIPTION
I hope it fix #575 

The problem was that there are sub-packages can be found both src and src-gen. (It is caused by xtend code generation) So when we export one of them we store in cache and the exporter believes the duplicated package is already exported. 

The solution is merging the coherent sub-packages to a list and we pass a package list to the package exporter instead of one package.  