### PR TITLE
Releng hotfixes related to Xtend and PlantUML

### DIFF
--- a/dev/releng/hu.elte.txtuml.parent/pom.xml
+++ b/dev/releng/hu.elte.txtuml.parent/pom.xml
@@ -266,6 +266,36 @@
 							</configuration>
 						</execution>
 					</executions>
+					<dependencies>
+						<!-- make EMF v2.12 dependencies explicit, see
+							 https://github.com/eclipse/xtext/issues/1231#issuecomment-421418880 -->
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.common</artifactId>
+							<version>2.12.0</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.ecore</artifactId>
+							<version>2.12.0</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.ecore.xmi</artifactId>
+							<version>2.12.0</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen</artifactId>
+							<version>2.11.0</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen.ecore</artifactId>
+							<version>2.12.0</version>
+						</dependency>
+						<!-- end of explicit EMF v2.12 dependencies -->
+					</dependencies>
 				</plugin>
 
 				<!--This plugin's configuration is used to store Eclipse m2e settings only. 

--- a/dev/releng/hu.elte.txtuml.target/release.target
+++ b/dev/releng/hu.elte.txtuml.target/release.target
@@ -28,7 +28,8 @@
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 			<unit id="net.sourceforge.plantuml.feature.feature.group" version="1.1.19"/>
-			<repository location="http://files.idi.ntnu.no/publish/plantuml/repository/"/>
+			<repository location="http://mextest.inf.elte.hu/updates/mirrors/plantuml"/>
+			<!-- hotfix, switch back to the official update site on the next release -->
 		</location>
 	</locations>
 	<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>


### PR DESCRIPTION
This pull request resolves two releng bugs that made our Maven builds fail. Both problems were related to dependencies and were resolved by hotfixes which should be dealt with during the next txtUML release. See the full commit messages for additional details.

Affected build profiles were tested internally by a Jenkins job, see [fix-xtend-plantuml-releng/1](https://mextest.inf.elte.hu/jenkins/job/fix-xtend-plantuml-releng/1/) (mirror target) and [fix-xtend-plantuml-releng/4](https://mextest.inf.elte.hu/jenkins/job/fix-xtend-plantuml-releng/4/) (release target). The referenced builds require Jenkins permission and will likely be deleted soon after this pull request is merged.

Bugs fixed here currently block other pull requests, therefore merging this is top priority.